### PR TITLE
fix: add database init entrypoint

### DIFF
--- a/database/init.js
+++ b/database/init.js
@@ -1,0 +1,20 @@
+const { Database } = require('./db');
+
+async function main() {
+  const db = new Database();
+
+  try {
+    await db.initialize();
+    await db.close();
+    console.log('Database initialized successfully.');
+  } catch (error) {
+    console.error('Failed to initialize database:', error);
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { main };


### PR DESCRIPTION
## Summary

Add the missing `database/init.js` entrypoint used by the existing `npm run db:init` script.

## Bug

`package.json` defines:

```json
"db:init": "node database/init.js"
```

but `database/init.js` did not exist, so the command failed before it could initialize the SQLite database.

## Before/After

Before:
```bash
npm run db:init
# Error: Cannot find module './database/init.js'
```

After:
```bash
npm run db:init
# Database initialized successfully.
```

The new entrypoint reuses the existing `Database` class, initializes the schema/settings, closes the connection, and exits non-zero if initialization fails.

## Verification

- `npm ci`
- `node -c database/init.js`
- `npm run db:init`