### PR TITLE
Add Windows one-click launcher (start.bat)

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,16 @@
+@echo off
+title YouTube Automation Agent
+cd /d "%~dp0"
+if not exist logs mkdir logs
+echo ================================
+echo  YouTube Automation Agent
+echo  Dashboard: http://localhost:3456
+echo ================================
+echo.
+echo Starting... output is logged to logs\app.log
+echo Press Ctrl+C to stop.
+echo.
+node index.js >> logs\app.log 2>&1
+echo.
+echo Agent stopped. See logs\app.log for details.
+pause


### PR DESCRIPTION
## Summary

- **Add `start.bat`** — a Windows one-click launcher that starts the automation agent with a double-click. It automatically creates the `logs/` directory and appends all stdout/stderr to `logs/app.log` so errors are captured even when the console window is closed.
- **Refresh `package-lock.json`** — regenerated after a clean `npm install` which resolved newer package versions (`googleapis` 128→173, `openai` 4→6, `@google/generative-ai` → `@google/genai` 2.9.0, `axios` 1.6→1.7, `replicate` 1.0→1.4).

## Why

Windows users currently have no quick way to start the agent without opening a terminal and typing `node index.js`. `start.bat` reduces the friction to a single double-click and ensures logs are always written to disk.

## Test plan

- [ ] Double-click `start.bat` on Windows — confirm console opens with the startup banner
- [ ] Open http://localhost:3456 — confirm dashboard loads
- [ ] `GET /health` returns `{ "status": "ok" }`
- [ ] Verify `logs/app.log` is created and receives output
- [ ] Press Ctrl+C to stop — confirm `pause` holds the window open for error review

🤖 Generated with [Claude Code](https://claude.com/claude-code)