### PR TITLE
fix(setup): validate selected AI provider credentials

### DIFF
--- a/tests/credential-manager-validation.test.js
+++ b/tests/credential-manager-validation.test.js
@@ -1,0 +1,50 @@
+const assert = require('assert');
+
+const { CredentialManager } = require('../utils/credential-manager');
+
+function managerWith(credentials) {
+  const manager = new CredentialManager();
+  manager.loadCredentials = async () => {
+    manager.credentials = credentials;
+  };
+  manager.loadTokens = async () => {
+    manager.tokens = { youtube: { access_token: 'token' } };
+  };
+  return manager;
+}
+
+async function main() {
+  assert.strictEqual(
+    await managerWith({
+      aiService: 'gemini',
+      youtube: {},
+      gemini: { apiKey: 'gemini-key' },
+    }).validateAll(),
+    true,
+    'Gemini setup should validate without OpenAI credentials',
+  );
+
+  assert.strictEqual(
+    await managerWith({
+      aiService: 'openai',
+      youtube: {},
+      gemini: { apiKey: 'gemini-key' },
+    }).validateAll(),
+    false,
+    'OpenAI setup should still require OpenAI credentials',
+  );
+
+  assert.strictEqual(
+    await managerWith({
+      youtube: {},
+      gemini: { apiKey: 'gemini-key' },
+    }).validateAll(),
+    true,
+    'Existing configs without aiService should accept any configured AI provider',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/utils/credential-manager.js
+++ b/utils/credential-manager.js
@@ -519,11 +519,15 @@ class CredentialManager {
       // Files might not exist yet
     }
 
-    const requiredCredentials = ['youtube', 'openai'];
+    const requiredCredentials = ['youtube', ...this.getRequiredAIServices()];
     const missing = [];
 
     for (const service of requiredCredentials) {
-      if (!this.credentials[service]) {
+      if (Array.isArray(service)) {
+        if (!service.some(option => this.credentials[option])) {
+          missing.push(service.join(' or '));
+        }
+      } else if (!this.credentials[service]) {
         missing.push(service);
       }
     }
@@ -540,6 +544,17 @@ class CredentialManager {
     }
 
     return true;
+  }
+
+  getRequiredAIServices() {
+    const supportedAIServices = ['openai', 'gemini', 'openrouter', 'kimi', 'mimo', 'glm'];
+    const selectedService = this.credentials.aiService;
+
+    if (supportedAIServices.includes(selectedService)) {
+      return [selectedService];
+    }
+
+    return [supportedAIServices];
   }
 
   async testConnections() {
@@ -624,6 +639,9 @@ class CredentialManager {
         ]
       }
     ]);
+
+    this.credentials.aiService = service;
+    await this.saveCredentials();
 
     switch (service) {
       case 'openai': return await this.setupOpenAICredentials();


### PR DESCRIPTION
## Problem

The setup wizard lets users choose Gemini and other AI providers, but final credential validation still hardcodes OpenAI as required. A Gemini-only setup can therefore fail at the end with `Missing credentials for: openai` even though the selected provider was configured.

Closes #9

## Before / after

Before:
- `validateAll()` always required `youtube` and `openai` credentials.
- Gemini-only users could not complete setup validation.

After:
- The wizard records the selected AI provider as `aiService`.
- Validation requires the selected provider's credentials.
- Existing configs without `aiService` remain compatible by accepting any configured supported AI provider.

## Verification

- `npm install` to install local dependencies for the fresh clone; lockfile changes were not committed.
- `node tests/credential-manager-validation.test.js`
- `node -c utils/credential-manager.js`
- `node -c tests/credential-manager-validation.test.js`
- `git diff --cached --check`
