### PR TITLE
v2.5: Add OmniRoute self-hosted AI gateway support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,12 @@
 # YouTube Automation Agent Environment Configuration
 # Copy this file to .env and fill in your actual values
 
-# AI Provider - Pick one (or use OpenRouter for access to all)
+# AI Provider - Pick one (or use OmniRoute/OpenRouter for access to many providers)
 # Uncomment the line you use — placeholder values must stay commented out
+# OmniRoute is an OpenAI-compatible self-hosted gateway. See docs/OMNIROUTE.md.
+# OMNIROUTE_BASE_URL=http://127.0.0.1:20128/v1
+# OMNIROUTE_API_KEY=your-omniroute-api-key-here
+# OMNIROUTE_MODEL=auto/smart
 # OPENAI_API_KEY=your-openai-api-key-here
 # OPENROUTER_API_KEY=your-openrouter-api-key-here
 # GEMINI_API_KEY=your-gemini-api-key-here

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # YouTube Automation Agent
 
+> Using a self-hosted AI gateway? See the [OmniRoute walkthrough](docs/OMNIROUTE.md)
+> for routing, failover, environment configuration, and validation.
+
 ## What's New in v2.4
 
 - **Guided walkthrough for first-time setup** — `npm run walkthrough` (also offered when you run `npm run setup`). It explains every choice in plain English, shows exactly where to get each key (and opens the page in your browser), **live-tests keys the moment you paste them**, walks you click-by-click through Google Cloud for the YouTube connection, and signs you in via your browser instead of copy-pasting auth codes. Every step is skippable and progress is saved — re-run it any time.

--- a/docs/OMNIROUTE.md
+++ b/docs/OMNIROUTE.md
@@ -1,0 +1,105 @@
+# OmniRoute walkthrough
+
+OmniRoute can be used as this project's text-generation gateway. The app sends
+OpenAI-compatible chat-completion requests to OmniRoute; OmniRoute owns upstream
+provider credentials, model routing, quotas, and failover.
+
+This integration affects script/text generation only. Images, TTS, and video
+generation still need the media providers documented in `.env.example`.
+
+## 1. Start and configure OmniRoute
+
+Run your OmniRoute instance and open its dashboard (the standard local address
+is `http://127.0.0.1:20128`). In OmniRoute:
+
+1. Add at least one upstream provider account.
+2. Test the provider from the OmniRoute dashboard.
+3. Create or confirm the combo/model you want this app to call, for example
+   `auto/smart`.
+4. Configure an API key for clients if your instance requires one.
+
+Do not copy upstream provider credentials into this repository. Keep them in
+OmniRoute; this app needs only OmniRoute's client key.
+
+## 2. Verify OmniRoute independently
+
+Before configuring the app, verify its OpenAI-compatible inference surface:
+
+```bash
+export OMNIROUTE_BASE_URL=http://127.0.0.1:20128/v1
+export OMNIROUTE_API_KEY='replace-with-your-client-key'
+
+curl -fsS "$OMNIROUTE_BASE_URL/models" \
+  -H "Authorization: Bearer $OMNIROUTE_API_KEY"
+```
+
+Then test the exact combo/model:
+
+```bash
+curl -fsS "$OMNIROUTE_BASE_URL/chat/completions" \
+  -H "Authorization: Bearer $OMNIROUTE_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"auto/smart","messages":[{"role":"user","content":"Reply with: OK"}],"max_tokens":16}'
+```
+
+The base URL must include `/v1`. The management API uses `/api/*`; do not use a
+management URL as the inference base URL.
+
+## 3. Configure this project
+
+Recommended interactive setup:
+
+```bash
+npm run walkthrough
+```
+
+Choose `OmniRoute`, enter the OmniRoute client key, and select a combo. To use a
+remote or nonstandard instance, set `OMNIROUTE_BASE_URL` before running the
+walkthrough.
+
+Environment-only setup is also supported:
+
+```env
+OMNIROUTE_BASE_URL=http://127.0.0.1:20128/v1
+OMNIROUTE_API_KEY=replace-with-your-client-key
+OMNIROUTE_MODEL=auto/smart
+```
+
+Never commit `.env` or `config/credentials.json`.
+
+## 4. Validate the app
+
+```bash
+npm test
+npm run lint
+```
+
+Generate one draft privately before enabling scheduled uploads. Confirm the logs
+show `OmniRoute initialized` and the expected model/combo. The interactive
+credential wizard is available with `npm run credentials:setup` if you need to
+change only the provider later.
+
+## Troubleshooting
+
+- `404`: the base URL usually lacks `/v1`, or points at `/api` management routes.
+- `401`/`403`: the client key is missing/invalid, or OmniRoute rejected the
+  selected upstream account.
+- `model not found`: check `GET /v1/models` and use an exact returned combo/model
+  identifier.
+- intermittent upstream errors: test provider health in OmniRoute, disable an
+  exhausted account there, and keep failover logic in OmniRoute rather than in
+  this app.
+- images or narration fail while scripts work: OmniRoute is text-only in this
+  integration; configure a media provider separately.
+
+## Architecture
+
+```text
+YouTube Automation Agent
+  -> OMNIROUTE_BASE_URL (/v1/chat/completions)
+    -> OmniRoute combo/router
+      -> configured upstream provider(s)
+```
+
+The app intentionally treats OmniRoute as one gateway. Upstream providers and
+their fallback policy remain separated from application configuration.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "youtube-automation-agent",
-  "version": "2.2.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "youtube-automation-agent",
-      "version": "2.2.0",
+      "version": "2.4.0",
       "dependencies": {
         "@google-cloud/local-auth": "^3.0.0",
         "@google/genai": "^2.9.0",

--- a/utils/ai-text-service.js
+++ b/utils/ai-text-service.js
@@ -2,6 +2,13 @@ const OpenAI = require('openai');
 const { Logger } = require('./logger');
 
 const PROVIDERS = {
+  omniroute: {
+    name: 'OmniRoute',
+    baseURL: process.env.OMNIROUTE_BASE_URL || 'http://127.0.0.1:20128/v1',
+    defaultModel: process.env.OMNIROUTE_MODEL || 'auto/smart',
+    models: ['auto/smart', 'auto/best-fast', 'auto/best-coding', 'auto/pro-reasoning'],
+    envKey: 'OMNIROUTE_API_KEY',
+  },
   openai: {
     name: 'OpenAI',
     baseURL: 'https://api.openai.com/v1',
@@ -54,9 +61,11 @@ class AITextService {
     const provider = credentials.aiProvider?.provider;
     const apiKey = credentials.aiProvider?.apiKey;
     const model = credentials.aiProvider?.model;
+    const baseURL = credentials.aiProvider?.baseURL;
 
     if (provider && PROVIDERS[provider] && apiKey) {
-      return this._initOpenAICompatible(PROVIDERS[provider], apiKey, model);
+      const preset = baseURL ? { ...PROVIDERS[provider], baseURL } : PROVIDERS[provider];
+      return this._initOpenAICompatible(preset, apiKey, model);
     }
 
     for (const [, preset] of Object.entries(PROVIDERS)) {

--- a/utils/credential-manager.js
+++ b/utils/credential-manager.js
@@ -260,6 +260,45 @@ class CredentialManager {
     console.log(chalk.green('OpenRouter configured successfully!'));
   }
 
+  // OmniRoute Setup
+  async setupOmniRouteCredentials() {
+    console.log(chalk.cyan('\nOmniRoute Setup'));
+    console.log(chalk.gray('See docs/OMNIROUTE.md. The inference URL must end in /v1.'));
+
+    const answers = await inquirer.prompt([
+      {
+        type: 'input',
+        name: 'baseURL',
+        message: 'OmniRoute inference URL:',
+        default: process.env.OMNIROUTE_BASE_URL || 'http://127.0.0.1:20128/v1',
+        validate: input => /^https?:\/\/.+\/v1\/?$/.test(input.trim()) || 'Enter an HTTP(S) URL ending in /v1'
+      },
+      {
+        type: 'password',
+        name: 'apiKey',
+        message: 'OmniRoute client API key:',
+        validate: input => input.length > 0 || 'API key is required'
+      },
+      {
+        type: 'input',
+        name: 'model',
+        message: 'OmniRoute model or combo:',
+        default: process.env.OMNIROUTE_MODEL || 'auto/smart',
+        validate: input => input.trim().length > 0 || 'Model or combo is required'
+      }
+    ]);
+
+    this.credentials.aiProvider = {
+      provider: 'omniroute',
+      baseURL: answers.baseURL.replace(/\/$/, ''),
+      apiKey: answers.apiKey,
+      model: answers.model.trim()
+    };
+
+    await this.saveCredentials();
+    console.log(chalk.green('OmniRoute configured successfully!'));
+  }
+
   // Kimi (Moonshot AI) Setup
   async setupKimiCredentials() {
     console.log(chalk.cyan('\nKimi (Moonshot AI) Setup'));
@@ -538,7 +577,7 @@ class CredentialManager {
     }
 
     if (!this.hasAITextProvider()) {
-      missing.push('an AI provider (OpenAI, Gemini, OpenRouter, Kimi, MiMo, or GLM)');
+      missing.push('an AI provider (OmniRoute, OpenAI, Gemini, OpenRouter, Kimi, MiMo, or GLM)');
     }
 
     return missing;
@@ -642,6 +681,7 @@ class CredentialManager {
         name: 'service',
         message: 'Select your preferred AI service:',
         choices: [
+          { name: 'OmniRoute (self-hosted routing + failover)', value: 'omniroute' },
           { name: 'OpenAI (GPT-5.5)', value: 'openai' },
           { name: 'Google Gemini (Gemini 3.5 — free tier)', value: 'gemini' },
           { name: 'OpenRouter (300+ models, one API key)', value: 'openrouter' },
@@ -653,6 +693,7 @@ class CredentialManager {
     ]);
 
     switch (service) {
+      case 'omniroute': return await this.setupOmniRouteCredentials();
       case 'openai': return await this.setupOpenAICredentials();
       case 'gemini': return await this.setupGeminiCredentials();
       case 'openrouter': return await this.setupOpenRouterCredentials();

--- a/walkthrough.js
+++ b/walkthrough.js
@@ -12,6 +12,36 @@ const { checkFFmpeg, ffmpegInstallHint } = require('./utils/ffmpeg');
 
 // Everything a beginner needs to know about each provider, in one place
 const AI_PROVIDER_GUIDE = {
+  omniroute: {
+    label: 'OmniRoute — self-hosted gateway with routing and failover',
+    keyUrl: 'http://127.0.0.1:20128',
+    keyHint: 'the API key configured in your OmniRoute instance',
+    instructions: [
+      'Start OmniRoute and open its dashboard',
+      'Add and test at least one upstream provider',
+      'Create or confirm a combo such as auto/smart',
+      'Keep the inference URL ending in /v1 (default: http://127.0.0.1:20128/v1)'
+    ],
+    models: ['auto/smart', 'auto/best-fast', 'auto/best-coding', 'auto/pro-reasoning'],
+    defaultModel: 'auto/smart',
+    covers: 'scripts only (configure Gemini, OpenAI, ElevenLabs, or Azure separately for media)',
+    save(credentials, apiKey, model) {
+      credentials.aiProvider = {
+        provider: 'omniroute',
+        apiKey,
+        model,
+        baseURL: process.env.OMNIROUTE_BASE_URL || 'http://127.0.0.1:20128/v1'
+      };
+    },
+    validationCreds: (apiKey, model) => ({
+      aiProvider: {
+        provider: 'omniroute',
+        apiKey,
+        model,
+        baseURL: process.env.OMNIROUTE_BASE_URL || 'http://127.0.0.1:20128/v1'
+      }
+    })
+  },
   gemini: {
     label: 'Google Gemini — FREE tier, no credit card (recommended for beginners)',
     keyUrl: 'https://aistudio.google.com/apikey',


### PR DESCRIPTION
## Summary
- Adds OmniRoute as a text-generation provider option alongside OpenAI, Gemini, OpenRouter, Kimi, MiMo, and GLM
- OmniRoute is an OpenAI-compatible self-hosted gateway that owns upstream provider credentials, model routing, quotas, and failover — the app only needs a single client key and combo/model (e.g. `auto/smart`)
- Wired through the credential setup wizard, guided walkthrough, `.env.example`, README, and a new `docs/OMNIROUTE.md` walkthrough doc

## Test plan
- [x] `node test.js` — 16/16 passed
- [x] `npm run lint` — 0 errors (only pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)