### PR TITLE
Fix slideshow dropping every generated image

### DIFF
--- a/test.js
+++ b/test.js
@@ -25,6 +25,7 @@ class SystemTest {
       { name: 'FFmpeg Resolution', test: () => this.testFFmpegResolution() },
       { name: 'Gemini Media Provider Selection', test: () => this.testGeminiMediaProvider() },
       { name: 'Slideshow Renderer', test: () => this.testSlideshowRenderer() },
+      { name: 'Slideshow Embeds Visual Assets', test: () => this.testSlideshowEmbedsVisualAssets() },
       { name: 'Evergreen Template Topics', test: () => this.testEvergreenTopics() },
       { name: 'Walkthrough Module', test: () => this.testWalkthroughModule() },
       { name: 'Logger System', test: () => this.testLogger() },
@@ -444,6 +445,57 @@ class SystemTest {
 
     this.logger.info('Slideshow renderer test completed successfully');
   }
+
+  async testSlideshowEmbedsVisualAssets() {
+    const { AIVideoGenerator } = require('./utils/ai-video-generator');
+    const { checkFFmpeg, runFFmpeg } = require('./utils/ffmpeg');
+    const fs = require('fs').promises;
+    const os = require('os');
+    const sharp = require('sharp');
+
+    if (!(await checkFFmpeg())) {
+      this.logger.warn('FFmpeg unavailable — skipping visual asset embedding test');
+      return;
+    }
+
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'yaa-embed-'));
+
+    try {
+      // A saturated red still. The default slide background is a blue/purple
+      // gradient, so "did the image render?" is answerable from channel means.
+      const imagePath = path.join(dir, 'asset.png');
+      await sharp({
+        create: { width: 1920, height: 1080, channels: 3, background: { r: 255, g: 0, b: 0 } }
+      }).png().toFile(imagePath);
+
+      const generator = new AIVideoGenerator({});
+      const script = {
+        title: 'Embedding Test',
+        mainContent: { sections: [{ title: 'Section One', content: 'Body copy.' }] }
+      };
+
+      const outputPath = path.join(dir, 'out.mp4');
+      await generator.generateSlideshowVideo(script, [imagePath], path.join(dir, 'missing.mp3'), outputPath);
+
+      const framePath = path.join(dir, 'frame.png');
+      await runFFmpeg(['-y', '-ss', '1', '-i', outputPath, '-frames:v', '1', framePath]);
+
+      const { channels } = await sharp(framePath).stats();
+      const [red, , blue] = channels.map(channel => channel.mean);
+
+      if (!(red > blue)) {
+        throw new Error(
+          `Visual asset never reached the frame (red ${red.toFixed(1)} <= blue ${blue.toFixed(1)}) — ` +
+          'the slideshow rendered its background instead of the supplied image'
+        );
+      }
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    }
+
+    this.logger.info('Visual asset embedding test completed successfully');
+  }
+
 
   async testEvergreenTopics() {
     const { ContentStrategyAgent } = require('./agents/content-strategy-agent');

--- a/utils/ai-video-generator.js
+++ b/utils/ai-video-generator.js
@@ -325,11 +325,19 @@ class AIVideoGenerator {
 
       // Create HTML for slideshow (only real image files can be embedded)
       const imageAssets = await this.filterImageAssets(visualAssets);
-      await page.setContent(this.createSlideshowHTML(script, imageAssets));
+
+      // Chromium refuses file:// subresources on an about:blank document, which
+      // is what setContent() gives us — every generated still was silently
+      // dropped. Serving the markup from a real file:// document keeps the
+      // origin consistent so the images actually load.
+      await fs.mkdir(slidesDir, { recursive: true });
+      const pagePath = path.join(slidesDir, 'slideshow.html');
+      await fs.writeFile(pagePath, this.createSlideshowHTML(script, imageAssets));
+      await page.goto(pathToFileURL(pagePath).href, { waitUntil: 'load' });
 
       // Freeze CSS transitions/animations so each still is captured fully rendered
       await page.addStyleTag({ content: '* { transition: none !important; animation: none !important; }' });
-      await page.waitForTimeout(1000); // Wait for assets to load
+      await this.waitForImagesToDecode(page);
 
       // Capture ONE still per slide instead of screenshotting at 30fps —
       // FFmpeg turns the stills into a crossfaded video in seconds.
@@ -403,6 +411,22 @@ class AIVideoGenerator {
 
     await runFFmpeg(args);
     return videoPath;
+  }
+
+  // Waiting on decode rather than a fixed timeout means a still that failed to
+  // load is reported instead of quietly screenshotting an empty slide.
+  async waitForImagesToDecode(page) {
+    const broken = await page.evaluate(async () => {
+      const images = Array.from(document.images);
+      await Promise.all(images.map(image => image.decode().catch(() => {})));
+      return images.filter(image => !image.naturalWidth).map(image => image.src);
+    });
+
+    if (broken.length) {
+      this.logger.warn(`${broken.length} slide image(s) failed to load: ${broken.join(', ')}`);
+    }
+
+    return broken;
   }
 
   async filterImageAssets(visualAssets = []) {


### PR DESCRIPTION
## The bug

`generateSlideshowVideo()` builds its markup with `page.setContent()`, which leaves the document on `about:blank`. Chromium refuses to load `file://` subresources from that origin, so **every image produced by `generateVisualAssets()` is silently discarded** and the slideshow always renders its background gradient.

This affects every provider — OpenAI, Gemini, Replicate. Image generation currently has no effect on the output no matter what is configured or paid for.

## Reproduction

Standalone, no project code required:

```js
const { chromium } = require('playwright');
const { pathToFileURL } = require('url');

const img = pathToFileURL('/path/to/any.png').href;
const browser = await chromium.launch();
const page = await browser.newPage();

// How the repo does it today:
await page.setContent(`<img id="a" src="${img}" />`);
await page.waitForTimeout(1500);
await page.evaluate(() => document.getElementById('a').naturalWidth);
// -> 0
// console: "Not allowed to load local resource: file:///path/to/any.png"

// Same image, page served from a file:// origin:
await page.goto('file:///tmp/probe.html');   // contains the same <img>
await page.evaluate(() => document.getElementById('a').naturalWidth);
// -> 1080
```

I also confirmed it end to end: I ran the pipeline with 9 real PNGs supplied as `visualAssets`. Not one pixel of any of them appeared in the rendered `.mp4`.

## Why it is easy to miss

The failure is completely invisible at runtime. The render succeeds, the `.mp4` is valid and playable, and the placeholder guard in `publishing-scheduling-agent.js` accepts it, because that guard checks the video file rather than its contents. `filterImageAssets()` even runs `fs.access()` on each still first, so the paths look verified right up to the point Chromium rejects them.

## The fix

Write the markup to a file inside the existing `slides` directory and `page.goto()` it, so the document and its images share a `file://` origin.

I also replaced the fixed `waitForTimeout(1000)` with a wait on image decode. That is both deterministic and loud: any still that fails to load is now logged rather than quietly screenshotted as an empty slide.

## Test

Adds `testSlideshowEmbedsVisualAssets` to `test.js`, following the existing suite's conventions. It renders a saturated red still through the real slideshow path and asserts the red channel dominates the resulting frame.

- On `master` it fails with `Visual asset never reached the frame (red 110.1 <= blue 196.9)` — those are the background gradient's channel means.
- With this change it passes.

Full suite: 17/17 passing. `npm run lint` reports no new warnings.

## Scope

Deliberately limited to this one bug. I found several other silent-degradation paths while testing (JSON truncation dropping scripts to boilerplate templates, no retry or model fallback on 5xx, video duration estimated from word count rather than measured from the audio, and `logger.error()` dropping the cause). Happy to open those separately if useful — I did not want to bury this fix in a large PR.

---

*Investigated and prepared with [Claude Code](https://claude.com/claude-code). The reproduction above and the regression test were both run and verified against this repo before opening.*
