### PR TITLE
fix: calculate publishing frequency from intervals

### DIFF
--- a/agents/publishing-scheduling-agent.js
+++ b/agents/publishing-scheduling-agent.js
@@ -413,7 +413,7 @@ class PublishingSchedulingAgent {
     
     const dates = published.map(p => new Date(p.publishedAt)).sort((a, b) => a - b);
     const totalDays = (dates[dates.length - 1] - dates[0]) / (1000 * 60 * 60 * 24);
-    const frequency = published.length / totalDays;
+    const frequency = (published.length - 1) / totalDays;
     
     if (frequency >= 1) return `${frequency.toFixed(1)} videos per day`;
     if (frequency >= 0.14) return `${(frequency * 7).toFixed(1)} videos per week`;

--- a/test.js
+++ b/test.js
@@ -21,6 +21,7 @@ class SystemTest {
       { name: 'Operator Workflow API', test: () => this.testOperatorWorkflowAPI() },
       { name: 'API Validation and Security', test: () => this.testAPIValidationAndSecurity() },
       { name: 'Publishing Safety', test: () => this.testPublishingSafety() },
+      { name: 'Publishing Frequency', test: () => this.testPublishingFrequency() },
       { name: 'Multi-Provider Credential Validation', test: () => this.testCredentialValidation() },
       { name: 'AI Text Service Token Compatibility', test: () => this.testAITextServiceTokenParams() },
       { name: 'Placeholder Scheduling Guard', test: () => this.testPlaceholderSchedulingGuard() },
@@ -340,6 +341,23 @@ class SystemTest {
     }
 
     this.logger.info('Publishing safety test completed successfully');
+  }
+
+  async testPublishingFrequency() {
+    const { PublishingSchedulingAgent } = require('./agents/publishing-scheduling-agent');
+    const agent = new PublishingSchedulingAgent({}, {});
+    const dailyPublications = [
+      { publishedAt: '2026-01-01T12:00:00.000Z' },
+      { publishedAt: '2026-01-02T12:00:00.000Z' },
+      { publishedAt: '2026-01-03T12:00:00.000Z' }
+    ];
+
+    const frequency = agent.calculatePublishingFrequency(dailyPublications);
+    if (frequency !== '1.0 videos per day') {
+      throw new Error(`Daily publishing cadence was reported as ${frequency}`);
+    }
+
+    this.logger.info('Publishing frequency test completed successfully');
   }
 
   async testCredentialValidation() {


### PR DESCRIPTION
## What & why

Publishing reports currently divide the number of publications by the elapsed time between the first and last timestamps. Because `N` publications contain only `N - 1` intervals, a daily three-publication sample is overstated as 1.5 videos per day. This change calculates the cadence from elapsed publication intervals.

## Regression evidence

- Before: `node -e "const { SystemTest } = require('./test'); new SystemTest().testPublishingFrequency()"` exited `1` and reported `1.5 videos per day`.
- After: the same command exited `0` and reports `1.0 videos per day`.

## Scope

- Updates the publishing-frequency calculation to use `N - 1` intervals.
- Adds one system regression test for three publications exactly one day apart.
- 2 files changed, +19 / -1 lines.

## Checklist

- [x] One focused concern per PR (split unrelated changes into separate PRs)
- [x] No `package-lock.json` regeneration unless the PR is specifically about dependencies
- [x] `npm run lint` passes
- [x] `npm test` passes (add a test if you fixed a bug)
- [x] Rebased on current `master`

## How I tested it

- `node -e "const { SystemTest } = require('./test'); new SystemTest().testPublishingFrequency()"`
- `npm test` — 19/19 system tests passed
- `npm run lint`
- `git diff --cached --check`
