### PR TITLE
Add finance Shorts workflows and media integrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@
 # OPENAI_API_KEY=your-openai-api-key-here
 # OPENROUTER_API_KEY=your-openrouter-api-key-here
 # GEMINI_API_KEY=your-gemini-api-key-here
+# ANTHROPIC_API_KEY=your-anthropic-api-key-here
+# ANTHROPIC_MODEL=claude-sonnet-4-5
 # MOONSHOT_API_KEY=your-kimi-api-key-here
 # MIMO_API_KEY=your-mimo-api-key-here
 # GLM_API_KEY=your-glm-api-key-here
@@ -13,6 +15,7 @@
 # ElevenLabs TTS (optional, higher quality than OpenAI TTS)
 # ELEVENLABS_API_KEY=your-elevenlabs-api-key-here
 # ELEVENLABS_VOICE_ID=your-voice-id-here
+# TTS_PROVIDER=auto
 
 # AI video generation (optional; local slideshow is the no-cost default)
 # VIDEO_PROVIDER=slideshow
@@ -63,6 +66,14 @@
 # AZURE_SPEECH_KEY=your-azure-speech-key-here
 # AZURE_SPEECH_REGION=eastus
 
+# Google Flow browser connector
+# FLOW_URL=https://labs.google/fx/tools/flow
+# FLOW_PROFILE_DIR=./config/flow-profile
+# FLOW_EDGE_PATH=C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe
+# FLOW_CONNECT_WAIT_MS=20000
+# FLOW_CDP_PORT=9222
+# FLOW_IMAGE_DIR=./data/finance-sample/flow-images
+
 # Application Settings
 NODE_ENV=production
 PORT=3456
@@ -76,6 +87,23 @@ TARGET_AUDIENCE=Your target audience description
 # YouTube Settings
 YOUTUBE_REGION=US
 DEFAULT_PRIVACY_STATUS=private
+YOUTUBE_CATEGORY_ID=27
+
+# One-shot Gemini Omni Flash YouTube Shorts workflow
+SHORT_DEFAULT_DURATION=10
+SHORT_ASPECT_RATIO=9:16
+SHORT_PRIVACY_STATUS=private
+
+# Finance Short batch (uses existing Flow stills; no image generation or paid animation)
+# TTS_PROVIDER=gemini
+# SHORT_BATCH_TTS_PROVIDER=gemini
+# Set SHORT_BATCH_TTS_PROVIDER=windows to use offline Windows System.Speech directly
+
+# Public Short safety cap (the workflow hard-caps this at 20 even if configured higher)
+YOUTUBE_PUBLIC_SHORTS_PER_DAY=20
+YOUTUBE_RATE_LIMIT_TIMEZONE=UTC
+# Delay between batch uploads; defaults to DEFAULT_DELAY_BETWEEN_POSTS when set
+# SHORT_BATCH_UPLOAD_DELAY_MS=60000
 
 # Content Settings
 AUTO_SHORTEN_CONTENT=true

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ yarn-error.log*
 .env.production
 config/credentials.json
 config/tokens.json
+config/flow-profile/
+config/flow-session.json
 config/*.key
 config/*.pem
 
@@ -90,3 +92,9 @@ data/thumbnails/
 
 # Claude worktrees
 .claude/worktrees/
+data/short-batch/
+data/short-batch-cartoon/
+data/finance-fact-sample/
+data/finance-sample/
+data/youtube-rate-limit.json
+data/.youtube-rate-limit.lock/

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ graph LR
 | **OpenAI** | GPT-5.6 Sol, Terra, Luna | `api.openai.com/v1` | provider pricing |
 | **OpenRouter** | 400+ models; curated defaults are validated against its live catalog | `openrouter.ai/api/v1` | varies by model |
 | **Google Gemini** | Gemini 3.7 Flash, 3.1 Pro Preview, 3.5 Flash-Lite | via `@google/genai` SDK | free tiers vary by model and modality |
+| **Anthropic Claude** | Claude Sonnet / Opus | `api.anthropic.com` | varies by model |
 | **Kimi (Moonshot AI)** | Kimi K3, K2.7 Code, K2.6 | `api.moonshot.ai/v1` | provider pricing |
 | **MiMo (Xiaomi)** | MiMo V2.5 Pro, V2.5 | `api.xiaomimimo.com/v1` | provider pricing |
 | **GLM (Zhipu AI)** | GLM-5.3, 5.2, 5.1 | `api.z.ai/api/paas/v4/` | provider pricing |
@@ -299,6 +300,8 @@ Long-form productions use hybrid assembly: Lumen generates bounded provider clip
 OPENAI_API_KEY=sk-...
 # OPENROUTER_API_KEY=sk-or-...
 # GEMINI_API_KEY=...
+# ANTHROPIC_API_KEY=...
+# ANTHROPIC_MODEL=claude-sonnet-4-5
 # MOONSHOT_API_KEY=...
 # MIMO_API_KEY=...
 # GLM_API_KEY=...
@@ -316,6 +319,11 @@ OPENAI_API_KEY=sk-...
 # KLING_ACCESS_KEY=...
 # KLING_SECRET_KEY=...
 # DASHSCOPE_API_KEY=...    # Wan 2.7
+
+# Optional: manually exported Google Flow images for the finance sample.
+# Name files scene_01.png through scene_08.png and place them in this directory.
+# FLOW_IMAGE_DIR=./data/finance-sample/flow-images
+# FLOW_CDP_PORT=9222
 
 # App config
 NODE_ENV=production
@@ -343,6 +351,76 @@ GENERATION_RETRY_BASE_MS=1000
 The dashboard calculates setup, first-real-MP4, approval, publication, and repeat-generation milestones locally from SQLite and files on disk. A video counts only when a non-simulated `.mp4` with an MP4 container signature still exists.
 
 Anonymous milestone reporting is disabled by default and has no built-in collector. It activates only when you explicitly set both telemetry variables. The allowlisted payload contains the milestone name and time, Lumen version, OS family, Node major version, and a random installation ID. It never includes credentials, channel data, prompts, topics, titles, filenames, or video contents.
+
+### Free Google Flow Stills
+
+The Flow connector uses a dedicated Edge profile and a local debugging port.
+It generates still images only; it never approves paid Flow animation jobs.
+
+```bash
+npm run flow:connect
+npm run flow:images
+npm run finance:sample
+```
+
+Keep the Flow project open while `flow:images` runs. Existing scene files are
+skipped, and the renderer uses local fallback artwork for any missing scene.
+
+## Finance Short Batch
+
+The first version of the finance batch changed the scene labels but reused the
+same small set of Flow stills for every Short. That made the visuals generic
+and repeated. The current batch uses a deterministic visual plan for each of
+the 20 topics and creates 12 topic-specific cartoon panels locally with SVG and
+Sharp. Each panel has a semantic illustration such as a repair bill, cash jar,
+calendar, shield, asset bucket, chart, or scam warning.
+
+The default output is the separate `data/short-batch-cartoon/` directory. The
+existing `data/short-batch/` manifest and public checkpoints are preserved and
+are never treated as cartoon renders. Flow stills are optional and are used
+only as a thumbnail reference when available. The card renderer still applies
+1080x1920 cards, Ken Burns motion, FFmpeg crossfades, and burned narration
+captions.
+
+This is cartoon-style 2D illustrated motion, not true AI character or object
+animation. Actual object or character animation would require a paid or
+external video model. No Gemini image generation or paid Flow animation is
+used by this batch.
+
+```bash
+# Default: generate all 20 locally for review; no YouTube calls
+npm run shorts:batch
+
+# Generate a smaller local preview
+npm run shorts:batch -- --count 5 --preview
+
+# Only after reviewing data/short-batch-cartoon/manifest.json, MP4s, and SRTs:
+npm run shorts:batch -- --count 20 --upload --public
+```
+
+The final MP4 burns short phrase captions with timing measured from the
+narration audio. The matching SRT remains beside each MP4. Gemini free TTS is
+used when available; on Windows, a local System.Speech fallback continues the
+batch after Gemini's free request quota is exhausted. Use
+`--youtube-captions` only when a separate YouTube caption track is needed;
+burned captions are included without that extra API call. Missing or simulated
+TTS fails the batch rather than silently publishing; use `--allow-silent` only
+for an intentional silent preview. `--public` requires `--upload`, and local
+generation is never an implicit upload. `data/short-batch-cartoon/manifest.json`
+records `visualStyle: "local cartoon illustrations"`, the 12 semantic
+`visualKinds`, the visual plan, completed files, and any YouTube checkpoints so
+reruns do not insert a completed cartoon Short again. Use `--output-dir` for a
+separate preview directory; the legacy `data/short-batch/` directory is
+blocked by the batch command to protect its public checkpoints.
+
+If YouTube temporarily rejects thumbnail requests, resume video uploads with
+`--skip-thumbnails`; the manifest keeps those thumbnails pending for a later
+retry.
+
+Public Shorts use a file-backed, cross-process-safe limit of 20 per calendar
+day. Set `YOUTUBE_RATE_LIMIT_TIMEZONE` (default `UTC`) for the date boundary
+and optionally lower `YOUTUBE_PUBLIC_SHORTS_PER_DAY`; values above 20 are
+ clamped. A failed public upload releases its reservation.
 
 ## Automation Schedule
 
@@ -452,6 +530,27 @@ curl -X POST http://localhost:3456/api/content/:contentId/approve \
   -H "x-api-key: $API_KEY" \
   -d '{"privacyStatus":"private","factChecked":true,"rightsConfirmed":true}'
 ```
+
+## Generate a Gemini Omni Flash Short
+
+The one-shot workflow accepts a prompt, saves a real MP4, and can upload it to
+YouTube through the existing OAuth connection. Uploads are private by default.
+
+```bash
+# Generate and review locally
+npm run short -- "A close-up cinematic shot of a glassblower shaping glowing blue glass"
+
+# Generate and upload privately
+npm run short -- "A close-up cinematic shot of a glassblower shaping glowing blue glass" --upload --privacy private
+
+# Publish publicly only when explicitly requested
+npm run short -- "A close-up cinematic shot of a glassblower shaping glowing blue glass" --upload --privacy public --title "Glassblower at Midnight"
+```
+
+The command uses `gemini-omni-flash-preview`, requests a 10-second 9:16 video,
+and writes the MP4 under `data/videos/`. Configure `GEMINI_API_KEY` and finish
+YouTube OAuth with `node modern-auth.js` before using `--upload`. Do not put API
+keys or OAuth tokens in prompts or commit them to the repository.
 
 ## Production Pipeline
 

--- a/agents/publishing-scheduling-agent.js
+++ b/agents/publishing-scheduling-agent.js
@@ -4,6 +4,12 @@ const fsSync = require('fs');
 const path = require('path');
 const { Logger } = require('../utils/logger');
 const { assertValidYouTubeMetadata } = require('../utils/youtube-metadata-validator');
+const {
+  isExplicitShort,
+  markPublicShortUploaded,
+  reservePublicShort,
+  releasePublicShort
+} = require('../utils/youtube-rate-limit');
 
 class PublishingSchedulingAgent {
   constructor(db, credentials) {
@@ -65,6 +71,8 @@ class PublishingSchedulingAgent {
         return existing;
       }
 
+      const explicitMetadata = productionData.metadata || {};
+
       const scheduleEntry = {
         productionId: productionData.id,
         title: productionData.script.title,
@@ -79,9 +87,11 @@ class PublishingSchedulingAgent {
           captions: productionData.assets.captions,
           privacyStatus: productionData.privacyStatus || process.env.DEFAULT_PRIVACY_STATUS || 'private',
           containsSyntheticMedia: productionData.containsSyntheticMedia === true,
-          contentType: productionData.contentType || 'long_form',
           sourceProductionId: productionData.sourceProductionId || productionData.id,
-          shortClipId: productionData.shortClipId || null
+          shortClipId: productionData.shortClipId || null,
+          isShort: productionData.isShort === true || explicitMetadata.isShort === true,
+          contentType: productionData.contentType || explicitMetadata.contentType || 'long_form',
+          aspectRatio: productionData.aspectRatio || explicitMetadata.aspectRatio
         },
         createdAt: new Date().toISOString()
       };
@@ -224,23 +234,38 @@ class PublishingSchedulingAgent {
     
     // Resolve the file before marking the network upload as attempted.
     const videoStream = await this.getVideoStream(metadata.video.path);
+    const publicShort = videoMetadata.status.privacyStatus === 'public' && isExplicitShort(metadata);
+    const reservation = publicShort
+      ? await reservePublicShort(`scheduled:${scheduleEntry.productionId || scheduleEntry.id}`)
+      : null;
     scheduleEntry.uploadAttempted = true;
-    const videoUpload = await this.youtube.videos.insert({
-      part: 'snippet,status',
-      requestBody: videoMetadata,
-      media: {
-        body: videoStream
-      }
-    });
-    
-    const videoId = videoUpload.data.id;
-    this.logger.info(`Video uploaded with ID: ${videoId}`);
-    scheduleEntry.status = 'uploaded';
-    scheduleEntry.youtubeId = videoId;
-    scheduleEntry.youtubeUrl = `https://www.youtube.com/watch?v=${videoId}`;
-    scheduleEntry.error = null;
-    await this.db.updateScheduleEntry(scheduleEntry);
-    
+    let inserted = false;
+    let videoUpload;
+    let videoId;
+    try {
+      videoUpload = await this.youtube.videos.insert({
+        part: 'snippet,status',
+        requestBody: videoMetadata,
+        media: {
+          body: videoStream
+        }
+      });
+
+      videoId = videoUpload.data.id;
+      if (!videoId) throw new Error('YouTube did not return an uploaded video ID');
+      inserted = true;
+      if (reservation) await markPublicShortUploaded(reservation.key);
+      this.logger.info(`Video uploaded with ID: ${videoId}`);
+      scheduleEntry.status = 'uploaded';
+      scheduleEntry.youtubeId = videoId;
+      scheduleEntry.youtubeUrl = `https://www.youtube.com/watch?v=${videoId}`;
+      scheduleEntry.error = null;
+      await this.db.updateScheduleEntry(scheduleEntry);
+    } catch (error) {
+      if (reservation && !inserted) await releasePublicShort(reservation.key).catch(() => {});
+      throw error;
+    }
+
     // Upload thumbnail
     if (metadata.thumbnail && metadata.thumbnail.path) {
       await this.uploadThumbnail(videoId, metadata.thumbnail.path);

--- a/config/credentials.example.json
+++ b/config/credentials.example.json
@@ -23,11 +23,19 @@
   "wan": {
     "apiKey": "YOUR_DASHSCOPE_API_KEY"
   },
+  "anthropic": {
+    "apiKey": "YOUR_ANTHROPIC_API_KEY",
+    "model": "claude-sonnet-4-5"
+  },
+  "elevenLabs": {
+    "apiKey": "YOUR_ELEVENLABS_API_KEY",
+    "voiceId": "YOUR_ELEVENLABS_VOICE_ID"
+  },
   "channel": {
     "channelName": "Your Channel Name",
     "channelDescription": "Your channel description.",
-    "defaultCategory": "24",
-    "defaultPrivacy": "public",
+    "defaultCategory": "27",
+    "defaultPrivacy": "private",
     "websiteUrl": "",
     "businessEmail": ""
   },

--- a/connect-google-flow.js
+++ b/connect-google-flow.js
@@ -1,0 +1,83 @@
+require('dotenv').config();
+
+const fs = require('fs').promises;
+const path = require('path');
+const { spawn, execFile } = require('child_process');
+const { promisify } = require('util');
+
+const execFileAsync = promisify(execFile);
+
+const profileDir = path.resolve(
+  process.env.FLOW_PROFILE_DIR || path.join(__dirname, 'config', 'flow-profile'),
+);
+const sessionFile = path.join(__dirname, 'config', 'flow-session.json');
+const flowUrl = process.env.FLOW_URL || 'https://labs.google/fx/tools/flow';
+const cdpPort = Number(process.env.FLOW_CDP_PORT || 9222);
+
+async function resolveEdgePath() {
+  if (process.env.FLOW_EDGE_PATH) {
+    return process.env.FLOW_EDGE_PATH;
+  }
+
+  const candidates = [
+    'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe',
+    'C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe',
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      await fs.access(candidate);
+      return candidate;
+    } catch {
+      // Try the next standard installation path.
+    }
+  }
+
+  const result = await execFileAsync('where.exe', ['msedge.exe']);
+  const discovered = result.stdout.split(/\r?\n/).map(value => value.trim()).find(Boolean);
+  if (!discovered) {
+    throw new Error('Microsoft Edge was not found. Set FLOW_EDGE_PATH in .env.');
+  }
+  return discovered;
+}
+
+async function main() {
+  await fs.mkdir(profileDir, { recursive: true });
+  const edgePath = await resolveEdgePath();
+  const edge = spawn(edgePath, [
+    `--user-data-dir=${profileDir}`,
+    `--remote-debugging-port=${cdpPort}`,
+    '--no-first-run',
+    '--no-default-browser-check',
+    flowUrl,
+  ], { detached: true, stdio: 'ignore' });
+  edge.unref();
+
+  console.log('Google Flow is open in a normal Microsoft Edge window.');
+  console.log('Sign in yourself and confirm that the Flow workspace is available.');
+  const waitMs = Number(process.env.FLOW_CONNECT_WAIT_MS || 20000);
+  await new Promise(resolve => setTimeout(resolve, waitMs));
+
+  await fs.writeFile(
+    sessionFile,
+    JSON.stringify({
+      connectedAt: new Date().toISOString(),
+      url: flowUrl,
+      browser: 'Microsoft Edge',
+      edgePath,
+      profileDir,
+      remoteDebuggingPort: cdpPort,
+      cdpUrl: `http://127.0.0.1:${cdpPort}`,
+      manualLoginRequired: true,
+      savedAfterMs: waitMs,
+    }, null, 2),
+    'utf8',
+  );
+
+  console.log(`Flow session saved locally at ${sessionFile}`);
+}
+
+main().catch(error => {
+  console.error(error.stack || error.message);
+  process.exitCode = 1;
+});

--- a/create-finance-sample.js
+++ b/create-finance-sample.js
@@ -1,0 +1,604 @@
+require('dotenv').config();
+
+const fs = require('fs').promises;
+const path = require('path');
+const { execFile } = require('child_process');
+const { promisify } = require('util');
+const sharp = require('sharp');
+const { AIVideoGenerator } = require('./utils/ai-video-generator');
+const { getFFmpegPath, runFFmpeg } = require('./utils/ffmpeg');
+
+const execFileAsync = promisify(execFile);
+const ROOT = __dirname;
+const OUTPUT_DIR = path.join(ROOT, 'data', 'finance-sample');
+const SOURCE_DIR = path.join(OUTPUT_DIR, 'source-images');
+const FLOW_IMAGE_DIR = path.resolve(
+  ROOT,
+  process.env.FLOW_IMAGE_DIR || path.join('data', 'finance-sample', 'flow-images'),
+);
+const CARD_DIR = path.join(OUTPUT_DIR, 'cards');
+const WIDTH = 1920;
+const HEIGHT = 1080;
+const SHORT_WIDTH = 1080;
+const SHORT_HEIGHT = 1920;
+const THUMB_WIDTH = 1280;
+const THUMB_HEIGHT = 720;
+
+const LONG_TITLE = 'How $100 a Month Could Grow With Compound Interest';
+const SHORT_TITLE = 'The $100 Habit That Could Become $59,000';
+const SOURCE_URL = 'https://www.investor.gov/financial-tools-calculators/calculators/compound-interest-calculator';
+
+const LONG_NARRATION = `Compound interest is one of the most important ideas in personal finance.
+
+It means your money can earn returns, and those returns can potentially earn additional returns over time.
+
+Here is a simple illustration.
+
+Imagine contributing one hundred dollars every month. If the money earned a hypothetical 8 percent annual return and compounded monthly, you would contribute twelve thousand dollars after 10 years. The account could be worth approximately eighteen thousand three hundred dollars.
+
+After 20 years, you would contribute twenty-four thousand dollars. The account could be worth approximately fifty-eight thousand nine hundred dollars.
+
+After 30 years, you would contribute thirty-six thousand dollars. The account could be worth approximately one hundred forty-nine thousand dollars.
+
+The important point is that the growth becomes larger over time. During the early years, most of the balance comes from your own contributions. Later, the accumulated balance has more opportunity to generate growth.
+
+This is why time can be more important than trying to find the perfect investment.
+
+However, this example has important limitations.
+
+An 8 percent return is only an assumption. Investments can rise or fall, and no return is guaranteed. Fees reduce investment results. Taxes may reduce what you keep. Inflation reduces the purchasing power of money over time.
+
+The example also assumes regular contributions and no withdrawals. Real life is less predictable.
+
+The practical lesson is not that everyone should expect 8 percent. The lesson is to understand how consistent saving and a long time horizon can affect potential growth.
+
+A person who starts with a manageable amount and increases contributions when their income grows may give compounding more time to work. Automating contributions can also make consistency easier.
+
+Before investing, learn about risk, diversification, account fees, and the difference between saving and investing. Money needed soon may require a different approach from money intended for a long-term goal.
+
+Use a reputable calculator to test different contribution amounts, time periods, and return assumptions.
+
+Compound interest is not a shortcut to guaranteed wealth. It is a mathematical process that rewards consistency and time.
+
+This video is for general education only and is not personalized financial advice. Consider your own situation and consult a qualified professional before making financial decisions.`;
+
+const SHORT_NARRATION = `What could one hundred dollars a month become?
+
+Using a hypothetical 8 percent annual return, compounded monthly, investing one hundred dollars every month for 20 years means you contribute twenty-four thousand dollars.
+
+The account could grow to about fifty-nine thousand dollars.
+
+That extra growth comes from your returns earning additional returns. This is compound growth.
+
+In the same example, one hundred dollars a month becomes about eighteen thousand dollars after 10 years, fifty-nine thousand after 20 years, and one hundred forty-nine thousand after 30 years.
+
+But 8 percent is not guaranteed. Real returns change, and fees, taxes, and inflation affect the result.
+
+The lesson is simple: start with an amount you can sustain, automate it, and give it time.
+
+Follow for practical finance facts. This content is educational, not financial advice.`;
+
+const SCENES = [
+  {
+    id: '01',
+    label: 'THE $100 HABIT',
+    detail: 'Small contributions can matter more with time',
+    prompt: 'A single gold coin placed at the bottom of a long elegant staircase, subtle glowing path leading upward, a calm anonymous adult silhouette in the distance, visual metaphor for starting small and building wealth over time',
+  },
+  {
+    id: '02',
+    label: 'YOUR CONTRIBUTIONS',
+    detail: '$100 every month',
+    prompt: 'A transparent glass savings jar receiving one gold coin at a time, repeated monthly rhythm suggested by soft circular calendar shapes, modern personal finance education scene, no text',
+  },
+  {
+    id: '03',
+    label: '20 YEARS LATER',
+    detail: 'About $58,900 in this illustration',
+    prompt: 'A glowing snowball made from small gold coins rolling gently down a wide hill and becoming much larger, cinematic financial growth metaphor, navy and amber palette, no text',
+  },
+  {
+    id: '04',
+    label: 'THE ENGINE',
+    detail: 'Returns can earn additional returns',
+    prompt: 'Nested golden circles and expanding rings of light around a central coin, elegant abstract visualization of compound growth, premium editorial finance illustration, no text',
+  },
+  {
+    id: '05',
+    label: 'THE TIMELINE',
+    detail: '10 years: $18.3K   20 years: $58.9K   30 years: $149K',
+    prompt: 'Three increasingly tall glowing columns made from stacked coins, arranged from left to right on a dark studio floor, clear visual comparison of time horizons, no numbers or text',
+  },
+  {
+    id: '06',
+    label: 'REALITY CHECK',
+    detail: '8% is an assumption, not a promise',
+    prompt: 'A balanced scale showing a growing coin stack on one side and abstract risk, fees, taxes, and inflation symbols on the other, thoughtful financial education visual, no logos, no text',
+  },
+  {
+    id: '07',
+    label: 'THE TAKEAWAY',
+    detail: 'Start small. Stay consistent. Give it time.',
+    prompt: 'An anonymous adult walking a long sunrise path while carrying a small glowing transparent savings jar, hopeful but realistic personal finance ending, no text',
+  },
+  {
+    id: '08',
+    label: 'EDUCATIONAL ONLY',
+    detail: 'Check the assumptions before making decisions',
+    prompt: 'Clean desktop with a calculator, notebook, and simple rising line drawn on paper, warm morning light, trustworthy financial education mood, no readable text, no brand logos',
+  },
+];
+
+const STYLE = 'Original editorial finance education artwork, cinematic 3D illustration, deep navy and warm amber palette, clean modern composition, realistic lighting, consistent visual language, no readable text, no letters, no company logos, no watermark, no stock ticker, no distorted hands.';
+
+function escapeXml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function wrapText(value, maxChars) {
+  const words = String(value).split(/\s+/);
+  const lines = [];
+  let line = '';
+
+  for (const word of words) {
+    const candidate = line ? `${line} ${word}` : word;
+    if (candidate.length > maxChars && line) {
+      lines.push(line);
+      line = word;
+    } else {
+      line = candidate;
+    }
+  }
+
+  if (line) lines.push(line);
+  return lines;
+}
+
+function textLines(lines, x, y, fontSize, lineHeight, options = {}) {
+  const anchor = options.anchor || 'start';
+  const fill = options.fill || '#ffffff';
+  const weight = options.weight || 700;
+  const family = options.family || 'Arial, sans-serif';
+  const shadow = options.shadow === false ? '' : ' filter="url(#shadow)"';
+
+  return `<text x="${x}" y="${y}" text-anchor="${anchor}" fill="${fill}" font-family="${family}" font-size="${fontSize}px" font-weight="${weight}"${shadow}>${lines.map((line, index) => `<tspan x="${x}" dy="${index === 0 ? 0 : lineHeight}">${escapeXml(line)}</tspan>`).join('')}</text>`;
+}
+
+function cardOverlay(scene, width, height, vertical = false) {
+  const margin = vertical ? 68 : 90;
+  const labelSize = vertical ? 48 : 52;
+  const detailSize = vertical ? 42 : 48;
+  const detailLines = wrapText(scene.detail, vertical ? 22 : 40);
+  const labelY = vertical ? height - 560 : height - 420;
+  const detailY = labelY + (vertical ? 76 : 86);
+  const footerY = height - margin;
+  const titleLines = vertical ? ['FINANCE', 'FACTS'] : ['FINANCE FACTS'];
+  const titleY = vertical ? margin + 66 : margin + 54;
+
+  return `
+    <svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <linearGradient id="shade" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stop-color="#061323" stop-opacity="0.08"/>
+          <stop offset="0.58" stop-color="#061323" stop-opacity="0.18"/>
+          <stop offset="1" stop-color="#061323" stop-opacity="0.94"/>
+        </linearGradient>
+        <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+          <feDropShadow dx="0" dy="4" stdDeviation="5" flood-color="#000000" flood-opacity="0.65"/>
+        </filter>
+      </defs>
+      <rect width="${width}" height="${height}" fill="url(#shade)"/>
+      <rect x="${margin}" y="${margin}" width="${vertical ? 280 : 330}" height="${vertical ? 112 : 72}" rx="18" fill="#f6b73c"/>
+      ${textLines(titleLines, margin + (vertical ? 28 : 165), titleY, vertical ? 36 : 34, 38, { anchor: vertical ? 'start' : 'middle', fill: '#071522', weight: 900, shadow: false })}
+      ${textLines([scene.label], margin, labelY, labelSize, labelSize + 8, { fill: '#ffffff', weight: 900 })}
+      ${textLines(detailLines, margin, detailY, detailSize, detailSize + 16, { fill: '#f6c75d', weight: 700 })}
+      <text x="${margin}" y="${footerY}" fill="#e6edf5" font-family="Arial, sans-serif" font-size="${vertical ? 26 : 24}px" font-weight="600" opacity="0.9">Hypothetical illustration | Educational content</text>
+    </svg>`;
+}
+
+function thumbnailOverlay() {
+  return `
+    <svg width="${THUMB_WIDTH}" height="${THUMB_HEIGHT}" viewBox="0 0 ${THUMB_WIDTH} ${THUMB_HEIGHT}" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <linearGradient id="thumbShade" x1="0" y1="0" x2="1" y2="0">
+          <stop offset="0" stop-color="#061323" stop-opacity="0.92"/>
+          <stop offset="0.58" stop-color="#061323" stop-opacity="0.42"/>
+          <stop offset="1" stop-color="#061323" stop-opacity="0.08"/>
+        </linearGradient>
+        <filter id="thumbShadow" x="-20%" y="-20%" width="140%" height="140%">
+          <feDropShadow dx="0" dy="7" stdDeviation="5" flood-color="#000000" flood-opacity="0.72"/>
+        </filter>
+      </defs>
+      <rect width="${THUMB_WIDTH}" height="${THUMB_HEIGHT}" fill="url(#thumbShade)"/>
+      <rect x="54" y="52" width="270" height="58" rx="14" fill="#f6b73c"/>
+      <text x="189" y="91" text-anchor="middle" fill="#071522" font-family="Arial, sans-serif" font-size="30px" font-weight="900">FINANCE FACTS</text>
+      <text x="62" y="292" fill="#ffffff" font-family="Arial, sans-serif" font-size="86px" font-weight="900" filter="url(#thumbShadow)">THE $100</text>
+      <text x="62" y="390" fill="#f6c75d" font-family="Arial, sans-serif" font-size="98px" font-weight="900" filter="url(#thumbShadow)">HABIT</text>
+      <text x="62" y="544" fill="#ffffff" font-family="Arial, sans-serif" font-size="62px" font-weight="900" filter="url(#thumbShadow)">COULD BECOME</text>
+      <text x="62" y="632" fill="#f6c75d" font-family="Arial, sans-serif" font-size="82px" font-weight="900" filter="url(#thumbShadow)">~$59K*</text>
+      <text x="62" y="684" fill="#e6edf5" font-family="Arial, sans-serif" font-size="22px" font-weight="600">Hypothetical example | Returns not guaranteed</text>
+    </svg>`;
+}
+
+async function ensureDirectories() {
+  await Promise.all([
+    fs.mkdir(OUTPUT_DIR, { recursive: true }),
+    fs.mkdir(SOURCE_DIR, { recursive: true }),
+    fs.mkdir(FLOW_IMAGE_DIR, { recursive: true }),
+    fs.mkdir(CARD_DIR, { recursive: true }),
+  ]);
+}
+
+async function findFlowImage(scene) {
+  const names = [
+    `scene_${scene.id}`,
+    `flow_scene_${scene.id}`,
+    `scene-${scene.id}`,
+    `flow-${scene.id}`,
+  ];
+  const extensions = ['.png', '.jpg', '.jpeg', '.webp'];
+
+  for (const name of names) {
+    for (const extension of extensions) {
+      const candidate = path.join(FLOW_IMAGE_DIR, `${name}${extension}`);
+      try {
+        await fs.access(candidate);
+        return candidate;
+      } catch {
+        // Try the next supported filename.
+      }
+    }
+  }
+
+  return null;
+}
+
+async function loadLocalCredentials() {
+  try {
+    const contents = await fs.readFile(path.join(ROOT, 'config', 'credentials.json'), 'utf8');
+    return JSON.parse(contents);
+  } catch {
+    return {};
+  }
+}
+
+async function createFallbackImage(scene, index) {
+  const hue = 210 + index * 11;
+  const svg = `
+    <svg width="1536" height="1024" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0" stop-color="hsl(${hue}, 55%, 13%)"/>
+          <stop offset="1" stop-color="hsl(${hue + 40}, 65%, 32%)"/>
+        </linearGradient>
+        <radialGradient id="glow" cx="50%" cy="45%" r="48%">
+          <stop offset="0" stop-color="#f6c75d" stop-opacity="0.8"/>
+          <stop offset="1" stop-color="#f6c75d" stop-opacity="0"/>
+        </radialGradient>
+      </defs>
+      <rect width="1536" height="1024" fill="url(#bg)"/>
+      <circle cx="770" cy="475" r="420" fill="url(#glow)"/>
+      <circle cx="770" cy="475" r="180" fill="#f6b73c" opacity="0.82"/>
+      <circle cx="770" cy="475" r="130" fill="#ffd978" opacity="0.65"/>
+      <path d="M0 850 C350 680 530 900 800 720 C1060 545 1200 800 1536 600 L1536 1024 L0 1024 Z" fill="#061323" opacity="0.74"/>
+      <g fill="#f6c75d" opacity="0.72">
+        <circle cx="190" cy="180" r="12"/><circle cx="1320" cy="210" r="9"/><circle cx="1180" cy="440" r="14"/><circle cx="320" cy="560" r="8"/>
+      </g>
+    </svg>`;
+  const output = path.join(SOURCE_DIR, `scene_${scene.id}_fallback.png`);
+  await sharp(Buffer.from(svg)).png().toFile(output);
+  return output;
+}
+
+async function generateSourceImages(generator) {
+  const assets = [];
+  let generatedCount = 0;
+  let fallbackCount = 0;
+  let flowCount = 0;
+  for (let index = 0; index < SCENES.length; index += 1) {
+    const scene = SCENES[index];
+    const output = path.join(SOURCE_DIR, `scene_${scene.id}.png`);
+    const flowImage = await findFlowImage(scene);
+
+    if (flowImage) {
+      await fs.copyFile(flowImage, output);
+      flowCount += 1;
+      assets.push(output);
+      console.log(`Imported Flow scene image ${scene.id}`);
+      continue;
+    }
+
+    try {
+      const generated = await generator.generateVisualAssets(`${scene.prompt}. ${STYLE}`, 'modern', 1);
+      const source = generated.find(asset => /\.(png|jpe?g|webp)$/i.test(asset));
+      if (!source) throw new Error('image provider returned no usable image file');
+      await fs.copyFile(source, output);
+      generatedCount += 1;
+      console.log(`Generated scene image ${scene.id}`);
+    } catch (error) {
+      console.warn(`Scene ${scene.id} image generation failed; using local fallback: ${error.message}`);
+      await createFallbackImage(scene, index);
+      await fs.rename(path.join(SOURCE_DIR, `scene_${scene.id}_fallback.png`), output);
+      fallbackCount += 1;
+    }
+
+    assets.push(output);
+  }
+  const providers = [];
+  if (flowCount > 0) providers.push('Google Flow (manual import)');
+  if (generatedCount > 0) providers.push('Gemini');
+  if (fallbackCount > 0) providers.push('local fallback');
+  return {
+    assets,
+    provider: providers.join(' + ') || 'local fallback',
+    flowCount,
+  };
+}
+
+async function createCard(source, scene, output, width, height, vertical = false) {
+  const overlay = Buffer.from(cardOverlay(scene, width, height, vertical));
+  await sharp(source)
+    .resize(width, height, { fit: 'cover', position: 'centre' })
+    .composite([{ input: overlay }])
+    .png()
+    .toFile(output);
+}
+
+async function createCards(sourceImages) {
+  const longCards = [];
+  const shortCards = [];
+
+  for (let index = 0; index < SCENES.length; index += 1) {
+    const scene = SCENES[index];
+    const longPath = path.join(CARD_DIR, `long_${scene.id}.png`);
+    const shortPath = path.join(CARD_DIR, `short_${scene.id}.png`);
+    await createCard(sourceImages[index], scene, longPath, WIDTH, HEIGHT);
+    await createCard(sourceImages[index], scene, shortPath, SHORT_WIDTH, SHORT_HEIGHT, true);
+    longCards.push(longPath);
+    shortCards.push(shortPath);
+  }
+
+  return { longCards, shortCards };
+}
+
+async function createThumbnail(source) {
+  const output = path.join(OUTPUT_DIR, 'thumbnail_final.jpg');
+  await sharp(source)
+    .resize(THUMB_WIDTH, THUMB_HEIGHT, { fit: 'cover', position: 'centre' })
+    .composite([{ input: Buffer.from(thumbnailOverlay()) }])
+    .jpeg({ quality: 90, progressive: true, optimizeScans: true })
+    .toFile(output);
+  return output;
+}
+
+function calculateOffset(durations, index, fade) {
+  return durations.slice(0, index).reduce((sum, value) => sum + value, 0) - (index * fade);
+}
+
+async function renderSlides(cards, durations, audioPath, outputPath) {
+  const visualPath = outputPath.replace(/\.mp4$/i, '_visual.mp4');
+  const fade = 0.55;
+  const args = ['-y'];
+
+  for (let index = 0; index < cards.length; index += 1) {
+    args.push('-loop', '1', '-t', String(durations[index]), '-i', cards[index]);
+  }
+
+  const filters = cards.map((_, index) => `[${index}:v]format=yuv420p,setsar=1[v${index}]`);
+  let current = '[v0]';
+  let outputLabel = 'vfade1';
+
+  for (let index = 1; index < cards.length; index += 1) {
+    const next = `[v${index}]`;
+    const target = `[${outputLabel}]`;
+    filters.push(`${current}${next}xfade=transition=fade:duration=${fade}:offset=${calculateOffset(durations, index, fade).toFixed(3)}${target}`);
+    current = target;
+    outputLabel = `vfade${index + 1}`;
+  }
+
+  filters.push(`${current}format=yuv420p[vfinal]`);
+  args.push(
+    '-filter_complex', filters.join(';'),
+    '-map', '[vfinal]',
+    '-r', '30',
+    '-c:v', 'libx264',
+    '-preset', 'veryfast',
+    '-crf', '20',
+    '-pix_fmt', 'yuv420p',
+    '-an',
+    visualPath,
+  );
+  await runFFmpeg(args);
+
+  await runFFmpeg([
+    '-y',
+    '-i', visualPath,
+    '-i', audioPath,
+    '-map', '0:v:0',
+    '-map', '1:a:0',
+    '-c:v', 'copy',
+    '-c:a', 'aac',
+    '-b:a', '128k',
+    '-shortest',
+    '-movflags', '+faststart',
+    outputPath,
+  ]);
+
+  await fs.unlink(visualPath).catch(() => {});
+}
+
+async function probeDuration(audioPath) {
+  try {
+    await execFileAsync(getFFmpegPath(), ['-hide_banner', '-i', audioPath], { maxBuffer: 2 * 1024 * 1024 });
+  } catch (error) {
+    const text = `${error.stdout || ''}\n${error.stderr || ''}`;
+    const match = text.match(/Duration:\s+(\d+):(\d+):(\d+\.\d+)/);
+    if (match) {
+      return Number(match[1]) * 3600 + Number(match[2]) * 60 + Number(match[3]);
+    }
+  }
+  return null;
+}
+
+function formatSrtTime(seconds) {
+  const safe = Math.max(0, seconds);
+  const hours = Math.floor(safe / 3600);
+  const minutes = Math.floor((safe % 3600) / 60);
+  const wholeSeconds = Math.floor(safe % 60);
+  const milliseconds = Math.floor((safe % 1) * 1000);
+  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${String(wholeSeconds).padStart(2, '0')},${String(milliseconds).padStart(3, '0')}`;
+}
+
+function createCaptions(text, duration) {
+  const words = text.trim().split(/\s+/);
+  const chunks = [];
+  for (let index = 0; index < words.length; index += 9) {
+    chunks.push(words.slice(index, index + 9).join(' '));
+  }
+
+  const totalWords = words.length;
+  let cursor = 0;
+  return chunks.map((chunk, index) => {
+    const chunkWords = chunk.split(/\s+/).length;
+    const chunkDuration = duration * (chunkWords / totalWords);
+    const start = cursor;
+    const end = cursor + chunkDuration;
+    cursor = end;
+    return `${index + 1}\n${formatSrtTime(start)} --> ${formatSrtTime(end)}\n${chunk}\n`;
+  }).join('\n');
+}
+
+async function generateAudio(generator, text, output, fallbackSeconds) {
+  if (process.env.REUSE_FINANCE_AUDIO === 'true') {
+    try {
+      const stats = await fs.stat(output);
+      if (stats.isFile() && stats.size > 0) {
+        const provider = String(process.env.TTS_PROVIDER || 'auto').toLowerCase() === 'gemini'
+          ? 'Gemini free tier (cached)'
+          : 'existing audio';
+        console.log(`Reusing existing narration ${output}`);
+        return { path: output, provider };
+      }
+    } catch {
+      // Generate narration when no reusable audio file exists.
+    }
+  }
+
+  try {
+    await generator.generateTTSAudio(text, output);
+    const stats = await fs.stat(output);
+    if (!stats.size) throw new Error('TTS output is empty');
+    const provider = String(process.env.TTS_PROVIDER || 'auto').toLowerCase() === 'gemini'
+      ? 'Gemini free tier'
+      : process.env.ELEVENLABS_API_KEY
+        ? 'ElevenLabs'
+        : 'Gemini fallback';
+    return { path: output, provider };
+  } catch (error) {
+    console.warn(`TTS generation failed; using a silent review track: ${error.message}`);
+    await runFFmpeg([
+      '-y',
+      '-f', 'lavfi',
+      '-i', 'anullsrc=r=24000:cl=mono',
+      '-t', String(fallbackSeconds),
+      '-q:a', '9',
+      output,
+    ]);
+    return { path: output, provider: 'silent fallback' };
+  }
+}
+
+async function writeManifest(manifest) {
+  await fs.writeFile(
+    path.join(OUTPUT_DIR, 'manifest.json'),
+    JSON.stringify(manifest, null, 2),
+    'utf8',
+  );
+}
+
+async function main() {
+  await ensureDirectories();
+  const generator = new AIVideoGenerator(await loadLocalCredentials());
+  const { assets: sourceImages, provider: imageProvider, flowCount } = await generateSourceImages(generator);
+  const { longCards, shortCards } = await createCards(sourceImages);
+  const thumbnail = await createThumbnail(sourceImages[2]);
+
+  const longAudio = await generateAudio(
+    generator,
+    LONG_NARRATION,
+    path.join(OUTPUT_DIR, 'long_narration.mp3'),
+    230,
+  );
+  const shortAudio = await generateAudio(
+    generator,
+    SHORT_NARRATION,
+    path.join(OUTPUT_DIR, 'short_narration.mp3'),
+    65,
+  );
+
+  const longDuration = await probeDuration(longAudio.path) || 190;
+  const shortDuration = await probeDuration(shortAudio.path) || 55;
+  const longVideo = path.join(OUTPUT_DIR, 'compound-interest-long.mp4');
+  const shortVideo = path.join(OUTPUT_DIR, 'compound-interest-short.mp4');
+
+  await renderSlides(longCards, [12, 25, 35, 35, 40, 35, 30, 15], longAudio.path, longVideo);
+  await renderSlides(shortCards.slice(0, 6), [8, 11, 12, 11, 10, 10], shortAudio.path, shortVideo);
+
+  const longCaptions = path.join(OUTPUT_DIR, 'compound-interest-long.srt');
+  const shortCaptions = path.join(OUTPUT_DIR, 'compound-interest-short.srt');
+  await fs.writeFile(longCaptions, createCaptions(LONG_NARRATION, longDuration), 'utf8');
+  await fs.writeFile(shortCaptions, createCaptions(SHORT_NARRATION, shortDuration), 'utf8');
+  await fs.writeFile(path.join(OUTPUT_DIR, 'long-script.txt'), LONG_NARRATION, 'utf8');
+  await fs.writeFile(path.join(OUTPUT_DIR, 'short-script.txt'), SHORT_NARRATION, 'utf8');
+  await fs.writeFile(path.join(OUTPUT_DIR, 'image-prompts.json'), JSON.stringify(SCENES, null, 2), 'utf8');
+
+  const requestedButNotConnected = ['ElevenLabs voice'];
+  if (flowCount === 0) requestedButNotConnected.push('Google Flow image generation');
+
+  const manifest = {
+    status: 'awaiting_approval',
+    publicUpload: false,
+    title: LONG_TITLE,
+    shortTitle: SHORT_TITLE,
+    source: SOURCE_URL,
+    assumptions: {
+      monthlyContribution: 100,
+      annualReturn: 0.08,
+      compounding: 'monthly',
+      disclaimer: 'Hypothetical illustration. Returns are not guaranteed. Fees, taxes, and inflation are excluded.',
+    },
+    providers: {
+      images: imageProvider,
+      narration: longAudio.provider,
+      editing: 'FFmpeg + Sharp',
+      requestedButNotConnected,
+    },
+    outputs: {
+      longVideo,
+      shortVideo,
+      thumbnail,
+      longCaptions,
+      shortCaptions,
+    },
+    generatedAt: new Date().toISOString(),
+  };
+  await writeManifest(manifest);
+
+  console.log(JSON.stringify({
+    status: manifest.status,
+    longVideo,
+    shortVideo,
+    thumbnail,
+    manifest: path.join(OUTPUT_DIR, 'manifest.json'),
+  }, null, 2));
+}
+
+main().catch(error => {
+  console.error(error.stack || error.message);
+  process.exitCode = 1;
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,7 @@ module.exports = [
       'node_modules/**',
       'coverage/**',
       'logs/**',
+      'config/flow-profile/**',
       'temp/**',
       'tmp/**',
       'uploads/**',
@@ -14,7 +15,9 @@ module.exports = [
       'data/captions/**',
       'data/scripts/**',
       'data/videos/**',
-      'data/thumbnails/**'
+      'data/thumbnails/**',
+      'data/short-batch/**',
+      'data/short-batch-cartoon/**'
     ]
   },
   js.configs.recommended,

--- a/finance-fact-sample.js
+++ b/finance-fact-sample.js
@@ -1,0 +1,147 @@
+require('dotenv').config();
+
+const fs = require('fs').promises;
+const path = require('path');
+const sharp = require('sharp');
+const { AIVideoGenerator } = require('./utils/ai-video-generator');
+const { canUseWindowsSpeech, generateWindowsSpeech } = require('./utils/local-tts');
+const { createCartoonIllustrations } = require('./utils/cartoon-illustrations');
+const { renderShortVideo } = require('./utils/short-video-renderer');
+const { runFFmpeg } = require('./utils/ffmpeg');
+
+const ROOT = __dirname;
+const OUTPUT_DIR = path.join(ROOT, 'data', 'finance-fact-sample');
+const TOPIC = 'How Casinos Make Money Without Every Player Losing';
+const SOURCE = 'https://www.gamblingcommission.gov.uk/public-and-players/guide/page/what-is-the-house-edge';
+const DISCLAIMER = 'Educational content only. Gambling involves risk and is not a financial strategy.';
+const FAST_SPEED = 1.12;
+const FAST_MODE = process.argv.includes('--fast') || process.env.FINANCE_SAMPLE_FAST === '1';
+
+const SEGMENTS = [
+  { title: 'The business model', detail: 'A casino does not need every customer to lose', kind: 'house', text: 'A casino does not need every customer to lose.' },
+  { title: 'Roulette example', detail: 'American roulette has 38 numbered slots', kind: 'chart', text: 'Look at American roulette as a simple example. It has thirty eight numbered slots.' },
+  { title: 'Red and black', detail: 'There are 18 red and 18 black slots', kind: 'bucket', text: 'There are eighteen red slots and eighteen black slots.' },
+  { title: 'The green slots', detail: 'Two green slots change the odds', kind: 'warning', text: 'But there are also two green slots.' },
+  { title: 'Betting red', detail: 'A red bet wins 18 times out of 38', kind: 'target', text: 'If you bet on red, you win on eighteen of thirty eight outcomes, not nineteen of thirty eight.' },
+  { title: 'The house edge', detail: 'The average mathematical edge is about 5.26 percent', kind: 'scale', text: 'That difference creates a mathematical house edge of about five point two six percent on that bet.' },
+  { title: 'One session', detail: 'A player can still win in the short term', kind: 'coins', text: 'This does not mean every player loses every session. Luck can move either way in the short term.' },
+  { title: 'Many bets', detail: 'Probability becomes more useful over a large volume', kind: 'chart', text: 'The edge becomes more useful to the business across a large number of bets.' },
+  { title: 'Repeat play', detail: 'Volume gives the odds more opportunities to work', kind: 'clock', text: 'More games and repeat play give that probability more opportunities to show up.' },
+  { title: 'More than games', detail: 'Casinos can also earn from rooms food and events', kind: 'people', text: 'The wider business may also earn from rooms, food, entertainment, and events.' },
+  { title: 'Gross revenue', detail: 'The edge is not the same as net profit', kind: 'receipt', text: 'The house edge describes expected gaming revenue before operating costs, not guaranteed net profit.' },
+  { title: 'The lesson', detail: 'Understand probability before risking money', kind: 'shield', text: `The lesson is to understand the odds and the risks. ${DISCLAIMER}` }
+];
+
+const NARRATION = SEGMENTS.map(segment => segment.text).join(' ');
+
+function thumbnailOverlay() {
+  return `<svg width="1280" height="720" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+      <linearGradient id="shade" x1="0" y1="0" x2="1" y2="0">
+        <stop offset="0" stop-color="#071526" stop-opacity="0.94"/>
+        <stop offset="0.72" stop-color="#071526" stop-opacity="0.38"/>
+        <stop offset="1" stop-color="#071526" stop-opacity="0.08"/>
+      </linearGradient>
+    </defs>
+    <rect width="1280" height="720" fill="url(#shade)"/>
+    <rect x="54" y="48" width="290" height="62" rx="14" fill="#f6c75d"/>
+    <text x="199" y="89" text-anchor="middle" fill="#071526" font-family="Arial, sans-serif" font-size="28" font-weight="900">MONEY MINUTE</text>
+    <text x="58" y="290" fill="#ffffff" font-family="Arial, sans-serif" font-size="68" font-weight="900">HOW CASINOS</text>
+    <text x="58" y="380" fill="#f6c75d" font-family="Arial, sans-serif" font-size="78" font-weight="900">MAKE MONEY</text>
+    <text x="58" y="650" fill="#ffffff" font-family="Arial, sans-serif" font-size="26" font-weight="700">House edge explained | Educational only</text>
+  </svg>`;
+}
+
+async function createThumbnail(sourcePath, outputPath) {
+  await sharp(sourcePath)
+    .resize(1280, 720, { fit: 'cover', position: 'centre' })
+    .composite([{ input: Buffer.from(thumbnailOverlay()) }])
+    .jpeg({ quality: 90, progressive: true })
+    .toFile(outputPath);
+}
+
+async function createNarration(outputPath) {
+  if (canUseWindowsSpeech()) {
+    await generateWindowsSpeech(NARRATION, outputPath);
+    return 'Windows System.Speech';
+  }
+
+  const generator = new AIVideoGenerator({});
+  await generator.generateTTSAudio(NARRATION, outputPath);
+  return 'AIVideoGenerator TTS';
+}
+
+async function createFasterNarration(inputPath, outputPath) {
+  await runFFmpeg([
+    '-y',
+    '-nostdin',
+    '-loglevel',
+    'error',
+    '-i',
+    inputPath,
+    '-filter:a',
+    `atempo=${FAST_SPEED}`,
+    '-vn',
+    '-c:a',
+    'libmp3lame',
+    '-q:a',
+    '2',
+    outputPath
+  ]);
+}
+
+async function main() {
+  const illustrationsDir = path.join(OUTPUT_DIR, 'illustrations');
+  const suffix = FAST_MODE ? '-fast' : '';
+  const cardsDir = path.join(OUTPUT_DIR, `cards${suffix}`);
+  const audioPath = path.join(OUTPUT_DIR, 'narration.mp3');
+  const renderAudioPath = FAST_MODE ? path.join(OUTPUT_DIR, 'narration-fast.mp3') : audioPath;
+  const videoPath = path.join(OUTPUT_DIR, `casino-house-edge-short${suffix}.mp4`);
+  const srtPath = path.join(OUTPUT_DIR, `casino-house-edge-short${suffix}.srt`);
+  const thumbnailPath = path.join(OUTPUT_DIR, `casino-house-edge-thumbnail${suffix}.jpg`);
+  const manifestPath = path.join(OUTPUT_DIR, `manifest${suffix}.json`);
+
+  await fs.mkdir(OUTPUT_DIR, { recursive: true });
+  const narrationProvider = await createNarration(audioPath);
+  if (FAST_MODE) await createFasterNarration(audioPath, renderAudioPath);
+  const illustrations = await createCartoonIllustrations(SEGMENTS, illustrationsDir, { topicKey: 'casino-house-edge-sample' });
+  const rendered = await renderShortVideo({
+    sourceImages: illustrations,
+    scenes: SEGMENTS.map(segment => ({
+      ...segment,
+      duration: segment.text.split(/\s+/).length
+    })),
+    narrationText: NARRATION,
+    audioPath: renderAudioPath,
+    outputPath: videoPath,
+    srtPath,
+    cardsDir,
+    captionMaxWords: 6,
+    fadeDuration: 0.45
+  });
+  await createThumbnail(illustrations[0], thumbnailPath);
+
+  const manifest = {
+    status: 'preview_ready',
+    title: TOPIC,
+    source: SOURCE,
+    disclaimer: DISCLAIMER,
+    playbackRate: FAST_MODE ? FAST_SPEED : 1,
+    narrationProvider,
+    outputs: { video: videoPath, captions: srtPath, thumbnail: thumbnailPath },
+    timedScenes: SEGMENTS.map((segment, index) => ({
+      title: segment.title,
+      narration: segment.text,
+      kind: segment.kind,
+      renderedDurationSeconds: rendered.durations[index]
+    })),
+    generatedAt: new Date().toISOString()
+  };
+  await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf8');
+  console.log(JSON.stringify({ status: manifest.status, videoPath, srtPath, thumbnailPath, manifestPath, duration: rendered.duration, playbackRate: manifest.playbackRate, narrationProvider }, null, 2));
+}
+
+main().catch(error => {
+  console.error(`Finance fact sample failed: ${error.stack || error.message}`);
+  process.exitCode = 1;
+});

--- a/flow-generate-images.js
+++ b/flow-generate-images.js
@@ -1,0 +1,124 @@
+require('dotenv').config();
+
+const fs = require('fs').promises;
+const path = require('path');
+const sharp = require('sharp');
+const { chromium } = require('playwright');
+
+const ROOT = __dirname;
+const CDP_URL = process.env.FLOW_CDP_URL || 'http://127.0.0.1:9222';
+const OUTPUT_DIR = path.resolve(
+  ROOT,
+  process.env.FLOW_IMAGE_DIR || path.join('data', 'finance-sample', 'flow-images'),
+);
+const PROMPTS_FILE = path.join(ROOT, 'data', 'finance-sample', 'image-prompts.json');
+const WAIT_MS = Number(process.env.FLOW_GENERATION_WAIT_MS || 360000);
+const SCENE_IDS = String(process.env.FLOW_SCENES || '01,02,03,04,05,06,07,08')
+  .split(',')
+  .map(value => value.trim())
+  .filter(Boolean);
+const STYLE = 'Original editorial finance education artwork, cinematic 3D illustration, deep navy and warm amber palette, clean modern composition, realistic lighting, consistent visual language, no readable text, no letters, no company logos, no watermark, no stock ticker, no distorted hands.';
+
+async function getPromptPage(browser) {
+  const pages = browser.contexts().flatMap(context => context.pages());
+  for (const page of pages) {
+    if (page.url().includes('/fx/tools/flow/project/')
+      && await page.locator('[role="textbox"][contenteditable="true"]').count()) {
+      return page;
+    }
+  }
+
+  throw new Error('No Flow project prompt page is open. Run npm run flow:connect and open a project.');
+}
+
+async function getMediaUrls(page) {
+  return page.locator('img').evaluateAll(images => images
+    .map(image => image.currentSrc || image.src)
+    .filter(src => src.includes('/api/trpc/media.getMediaUrlRedirect')));
+}
+
+async function startNewSession(page) {
+  const button = page.locator('button').filter({ hasText: 'New session' }).first();
+  if (!(await button.count())) throw new Error('Flow New session control was not found');
+  await button.click();
+  await page.waitForTimeout(1200);
+}
+
+async function submitStillPrompt(page, prompt) {
+  const editor = page.locator('[role="textbox"][contenteditable="true"]').first();
+  await editor.fill(prompt);
+
+  const createButton = page.locator('button[aria-disabled="false"]')
+    .filter({ hasText: 'Create' })
+    .last();
+  if (!(await createButton.count())) throw new Error('No enabled Flow image Create action was found');
+  await createButton.click();
+}
+
+async function waitForNewImage(page, before, sceneId) {
+  const deadline = Date.now() + WAIT_MS;
+  while (Date.now() < deadline) {
+    const current = await getMediaUrls(page);
+    const fresh = current.find(url => !before.has(url));
+    if (fresh) return fresh;
+
+    if (await page.locator('button').filter({ hasText: 'Try again' }).count()) {
+      throw new Error(`Flow reported an error while generating scene ${sceneId}`);
+    }
+
+    console.log(`Scene ${sceneId} still processing; media URLs: ${current.length}`);
+    await page.waitForTimeout(10000);
+  }
+
+  throw new Error(`Flow did not return scene ${sceneId} within ${WAIT_MS}ms`);
+}
+
+async function saveImage(page, url, sceneId) {
+  const response = await page.context().request.get(url, { timeout: 60000 });
+  if (!response.ok()) throw new Error(`Flow image download failed with HTTP ${response.status()}`);
+
+  const outputPath = path.join(OUTPUT_DIR, `scene_${sceneId}.png`);
+  await sharp(await response.body()).png().toFile(outputPath);
+  console.log(`Exported ${outputPath}`);
+}
+
+async function main() {
+  const scenes = JSON.parse(await fs.readFile(PROMPTS_FILE, 'utf8'))
+    .filter(scene => SCENE_IDS.includes(scene.id));
+  await fs.mkdir(OUTPUT_DIR, { recursive: true });
+
+  let browser;
+  try {
+    browser = await chromium.connectOverCDP(CDP_URL);
+  } catch {
+    throw new Error(`Flow CDP is unavailable at ${CDP_URL}. Run npm run flow:connect first.`);
+  }
+
+  let page = await getPromptPage(browser);
+  console.log('Flow still-image mode only: paid animation approvals will not be requested.');
+
+  for (const scene of scenes) {
+    const outputPath = path.join(OUTPUT_DIR, `scene_${scene.id}.png`);
+    try {
+      await fs.access(outputPath);
+      console.log(`Scene ${scene.id} already exported; skipping`);
+      continue;
+    } catch {
+      // Generate the missing scene below.
+    }
+
+    await startNewSession(page);
+    page = await getPromptPage(browser);
+    const before = new Set(await getMediaUrls(page));
+    const prompt = `Generate exactly one landscape still image for a personal finance education video: ${scene.prompt}. ${STYLE}`;
+    console.log(`Generating Flow scene ${scene.id}`);
+    await submitStillPrompt(page, prompt);
+    const imageUrl = await waitForNewImage(page, before, scene.id);
+    await saveImage(page, imageUrl, scene.id);
+  }
+}
+
+main().then(() => process.exit(0)).catch(error => {
+  console.error(error.stack || error.message);
+  process.exit(1);
+});

--- a/modern-auth.js
+++ b/modern-auth.js
@@ -32,9 +32,9 @@ class ModernAuth {
       const scopes = [
         'https://www.googleapis.com/auth/youtube.upload',
         'https://www.googleapis.com/auth/youtube',
+        'https://www.googleapis.com/auth/youtube.force-ssl',
         'https://www.googleapis.com/auth/youtube.readonly',
-        'https://www.googleapis.com/auth/yt-analytics.readonly',
-        'https://www.googleapis.com/auth/youtube.force-ssl'
+        'https://www.googleapis.com/auth/yt-analytics.readonly'
       ];
 
       // Start a temporary local server

--- a/package.json
+++ b/package.json
@@ -5,10 +5,20 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
+    "finance:sample": "node create-finance-sample.js",
+    "finance:fact:sample": "node finance-fact-sample.js",
+    "finance:fact:sample:fast": "node finance-fact-sample.js --fast",
+    "finance:publish": "node publish-finance-sample.js",
+    "flow:connect": "node connect-google-flow.js",
+    "flow:images": "node flow-generate-images.js",
+    "credentials:elevenlabs": "node setup-elevenlabs.js",
+    "credentials:anthropic": "node setup-anthropic.js",
     "setup": "node setup.js",
     "walkthrough": "node walkthrough.js",
     "growth:snapshot": "node scripts/growth/snapshot-github.js",
     "scheduler": "node schedules/daily-automation.js",
+    "short": "node shorts.js",
+    "shorts:batch": "node short-batch.js",
     "test": "node test.js",
     "agent:strategy": "node agents/content-strategy-agent.js",
     "agent:script": "node agents/script-writer-agent.js",
@@ -50,5 +60,12 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "allowScripts": {
+    "ffmpeg-static@5.3.0": true,
+    "sharp@0.33.5": true,
+    "sqlite3@5.1.7": true,
+    "protobufjs@7.6.4": true,
+    "@google/genai@2.10.0": true
   }
 }

--- a/publish-finance-sample.js
+++ b/publish-finance-sample.js
@@ -1,0 +1,261 @@
+require('dotenv').config();
+
+const fs = require('fs');
+const fsp = fs.promises;
+const path = require('path');
+const { CredentialManager } = require('./utils/credential-manager');
+const {
+  markPublicShortUploaded,
+  reservePublicShort,
+  releasePublicShort
+} = require('./utils/youtube-rate-limit');
+
+const ROOT = __dirname;
+const OUTPUT_DIR = path.join(ROOT, 'data', 'finance-sample');
+const STATE_PATH = path.join(OUTPUT_DIR, 'youtube-upload.json');
+const MANIFEST_PATH = path.join(OUTPUT_DIR, 'manifest.json');
+const EXPECTED_CHANNEL = process.env.CHANNEL_NAME || 'Nature Lover 2000';
+const CATEGORY_ID = String(process.env.YOUTUBE_CATEGORY_ID || '27');
+const SOURCE_URL = 'https://www.investor.gov/financial-tools-calculators/calculators/compound-interest-calculator';
+const DISCLAIMER = 'This content is for general education only and is not personalized financial advice. Returns are not guaranteed. Fees, taxes, and inflation can affect results.';
+
+const VIDEOS = [
+  {
+    key: 'long',
+    file: 'compound-interest-long.mp4',
+    captions: 'compound-interest-long.srt',
+    title: 'How $100 a Month Could Grow With Compound Interest',
+    description: `Compound interest is the process where returns can potentially earn additional returns over time.
+
+This hypothetical illustration assumes $100 contributed monthly, an 8% annual return, and monthly compounding. The example is not a promise or prediction.
+
+Source: ${SOURCE_URL}
+
+${DISCLAIMER}
+
+#PersonalFinance #CompoundInterest #FinancialLiteracy`,
+    tags: ['personal finance', 'compound interest', 'financial literacy', 'saving money', 'investing basics', 'long term investing', 'money habits'],
+  },
+  {
+    key: 'short',
+    isShort: true,
+    file: 'compound-interest-short.mp4',
+    captions: 'compound-interest-short.srt',
+    title: 'The $100 Habit That Could Become $59,000',
+    description: `A hypothetical compound-growth illustration using $100 contributed every month and an assumed 8% annual return.
+
+Source: ${SOURCE_URL}
+
+${DISCLAIMER}
+
+#Shorts #PersonalFinance #CompoundInterest`,
+    tags: ['Shorts', 'personal finance', 'compound interest', 'saving money', 'financial literacy', 'investing basics'],
+  },
+];
+
+function requirePublicApproval() {
+  if (!process.argv.slice(2).includes('--public')) {
+    throw new Error('Public upload is locked. Run: npm run finance:publish -- --public');
+  }
+}
+
+async function readState() {
+  try {
+    const state = JSON.parse(await fsp.readFile(STATE_PATH, 'utf8'));
+    state.videos ||= {};
+    return state;
+  } catch {
+    return { privacyStatus: 'public', channelId: null, channelTitle: null, videos: {} };
+  }
+}
+
+async function writeState(state) {
+  await fsp.writeFile(STATE_PATH, JSON.stringify(state, null, 2), 'utf8');
+}
+
+async function assertFile(fileName) {
+  const filePath = path.join(OUTPUT_DIR, fileName);
+  const stats = await fsp.stat(filePath);
+  if (!stats.isFile() || stats.size === 0) throw new Error(`Missing or empty upload file: ${filePath}`);
+  return filePath;
+}
+
+function sanitizeTags(tags) {
+  const result = [];
+  let total = 0;
+  for (const tag of tags) {
+    const value = String(tag).trim();
+    if (!value || total + value.length + 1 > 500) continue;
+    result.push(value);
+    total += value.length + 1;
+  }
+  return result;
+}
+
+async function uploadVideo(youtube, video, thumbnailPath, state) {
+  let checkpoint = state.videos[video.key];
+  const captionsPath = await assertFile(video.captions);
+
+  if (!checkpoint?.id) {
+    const videoPath = await assertFile(video.file);
+    const reservation = video.isShort === true
+      ? await reservePublicShort(`finance-sample:${video.key}`)
+      : null;
+    let inserted = false;
+    try {
+      const response = await youtube.videos.insert({
+        part: 'snippet,status',
+        requestBody: {
+          snippet: {
+            title: video.title,
+            description: video.description,
+            tags: sanitizeTags(video.tags),
+            categoryId: CATEGORY_ID,
+            defaultLanguage: 'en',
+            defaultAudioLanguage: 'en',
+          },
+          status: {
+            privacyStatus: 'public',
+            selfDeclaredMadeForKids: false,
+          },
+        },
+        media: { body: fs.createReadStream(videoPath) },
+      });
+
+      const id = response.data.id;
+      if (!id) throw new Error(`YouTube did not return an ID for ${video.key}`);
+      inserted = true;
+      if (reservation) await markPublicShortUploaded(reservation.key);
+      checkpoint = {
+        id,
+        url: `https://www.youtube.com/watch?v=${id}`,
+        title: video.title,
+        privacyStatus: 'public',
+        thumbnailAttached: false,
+        captionsAttached: false,
+        uploadedAt: new Date().toISOString(),
+      };
+      state.videos[video.key] = checkpoint;
+      await writeState(state);
+      console.log(`Uploaded ${video.key}: ${id}`);
+    } catch (error) {
+      if (reservation && !inserted) await releasePublicShort(reservation.key).catch(() => {});
+      throw error;
+    }
+  } else {
+    console.log(`Resuming ${video.key}; checkpointed as ${checkpoint.id}`);
+  }
+
+  if (!checkpoint.thumbnailAttached) {
+    await youtube.thumbnails.set({
+      videoId: checkpoint.id,
+      media: { body: fs.createReadStream(thumbnailPath) },
+    });
+    checkpoint.thumbnailAttached = true;
+    await writeState(state);
+    console.log(`Thumbnail attached to ${video.key}`);
+  }
+
+  if (!checkpoint.captionsAttached) {
+    try {
+      await youtube.captions.insert({
+        part: 'snippet',
+        requestBody: {
+          snippet: {
+            videoId: checkpoint.id,
+            language: 'en',
+            name: 'English Captions',
+            isDraft: false,
+          },
+        },
+        media: { body: fs.createReadStream(captionsPath) },
+      });
+      checkpoint.captionsAttached = true;
+      await writeState(state);
+      console.log(`Captions attached to ${video.key}`);
+    } catch (error) {
+      if (!/insufficient authentication scopes/i.test(error.message || '')) throw error;
+      console.warn(`Captions skipped for ${video.key}: the current OAuth token lacks the captions scope`);
+    }
+  }
+
+  return checkpoint;
+}
+
+async function verifyPublishedVideos(youtube, state) {
+  const ids = Object.values(state.videos).map(video => video.id).filter(Boolean);
+  const response = await youtube.videos.list({ part: 'snippet,status', id: ids });
+  return response.data.items.map(video => ({
+    id: video.id,
+    title: video.snippet.title,
+    privacyStatus: video.status.privacyStatus,
+    url: `https://www.youtube.com/watch?v=${video.id}`,
+  }));
+}
+
+async function updateManifest(channel, published, state) {
+  const manifest = JSON.parse(await fsp.readFile(MANIFEST_PATH, 'utf8'));
+  const videos = {};
+  for (const video of published) {
+    const key = Object.entries(state.videos).find(([, value]) => value.id === video.id)?.[0];
+    if (key) {
+      videos[key] = {
+        id: video.id,
+        url: video.url,
+        title: video.title,
+        privacyStatus: video.privacyStatus,
+        thumbnailAttached: state.videos[key].thumbnailAttached === true,
+        captionsAttached: state.videos[key].captionsAttached === true,
+      };
+    }
+  }
+
+  if (Object.keys(videos).length !== VIDEOS.length || published.some(video => video.privacyStatus !== 'public')) {
+    throw new Error('Published video verification did not confirm both videos are public');
+  }
+
+  manifest.status = 'published';
+  manifest.publicUpload = true;
+  manifest.publishedAt = new Date().toISOString();
+  manifest.youtube = {
+    channelId: channel.id,
+    channelTitle: channel.snippet.title,
+    videos,
+  };
+  await fsp.writeFile(MANIFEST_PATH, JSON.stringify(manifest, null, 2), 'utf8');
+}
+
+async function main() {
+  requirePublicApproval();
+  const thumbnailPath = await assertFile('thumbnail_final.jpg');
+  const credentials = new CredentialManager();
+  if (!(await credentials.initialize())) throw new Error('Could not load YouTube credentials');
+  const youtube = credentials.getYouTubeClient();
+
+  const channelResponse = await youtube.channels.list({ part: 'snippet', mine: true });
+  const channel = channelResponse.data.items?.[0];
+  if (!channel) throw new Error('No authenticated YouTube channel was found');
+  if (channel.snippet.title !== EXPECTED_CHANNEL) {
+    throw new Error(`Authenticated channel is "${channel.snippet.title}", expected "${EXPECTED_CHANNEL}"`);
+  }
+  console.log(`Verified channel: ${channel.snippet.title} (${channel.id})`);
+
+  const state = await readState();
+  state.channelId = channel.id;
+  state.channelTitle = channel.snippet.title;
+  state.privacyStatus = 'public';
+  await writeState(state);
+
+  for (const video of VIDEOS) {
+    await uploadVideo(youtube, video, thumbnailPath, state);
+  }
+
+  const published = await verifyPublishedVideos(youtube, state);
+  await updateManifest(channel, published, state);
+  console.log(JSON.stringify({ channel: channel.snippet.title, videos: published }, null, 2));
+}
+
+main().catch(error => {
+  console.error(`Finance publish failed: ${error.stack || error.message}`);
+  process.exitCode = 1;
+});

--- a/setup-anthropic.js
+++ b/setup-anthropic.js
@@ -1,0 +1,15 @@
+require('dotenv').config();
+
+const { CredentialManager } = require('./utils/credential-manager');
+
+async function main() {
+  const manager = new CredentialManager();
+  await manager.loadCredentials();
+  await manager.setupAnthropicCredentials();
+  console.log('Anthropic Claude credentials saved locally.');
+}
+
+main().catch(error => {
+  console.error(`Anthropic setup failed: ${error.message}`);
+  process.exitCode = 1;
+});

--- a/setup-elevenlabs.js
+++ b/setup-elevenlabs.js
@@ -1,0 +1,46 @@
+require('dotenv').config();
+
+const fs = require('fs').promises;
+const path = require('path');
+const inquirer = require('inquirer');
+
+const envPath = path.join(__dirname, '.env');
+
+function upsertEnv(contents, key, value) {
+  const line = `${key}=${value}`;
+  const pattern = new RegExp(`^${key}=.*$`, 'm');
+  if (pattern.test(contents)) {
+    return contents.replace(pattern, () => line);
+  }
+  return `${contents.trimEnd()}\n${line}\n`;
+}
+
+async function main() {
+  const current = await fs.readFile(envPath, 'utf8').catch(() => '');
+  const answers = await inquirer.prompt([
+    {
+      type: 'password',
+      name: 'apiKey',
+      message: 'Paste the ElevenLabs SECRET API key (hidden):',
+      mask: '*',
+      validate: value => value.trim().length > 0 || 'A secret API key is required',
+    },
+    {
+      type: 'input',
+      name: 'voiceId',
+      message: 'Enter the ElevenLabs Voice ID:',
+      default: process.env.ELEVENLABS_VOICE_ID || '',
+      validate: value => value.trim().length > 0 || 'A Voice ID is required',
+    },
+  ]);
+
+  let updated = upsertEnv(current, 'ELEVENLABS_API_KEY', answers.apiKey.trim());
+  updated = upsertEnv(updated, 'ELEVENLABS_VOICE_ID', answers.voiceId.trim());
+  await fs.writeFile(envPath, updated, 'utf8');
+  console.log('ElevenLabs credentials saved locally. Secret values were not printed.');
+}
+
+main().catch(error => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/short-batch.js
+++ b/short-batch.js
@@ -1,0 +1,1051 @@
+require('dotenv').config();
+
+const fs = require('fs').promises;
+const fsSync = require('fs');
+const path = require('path');
+const sharp = require('sharp');
+const { AIVideoGenerator } = require('./utils/ai-video-generator');
+const { CredentialManager } = require('./utils/credential-manager');
+const { runFFmpeg } = require('./utils/ffmpeg');
+const {
+  estimateNarrationDuration,
+  isUsableAudioFile,
+  renderShortVideo
+} = require('./utils/short-video-renderer');
+const {
+  markPublicShortUploaded,
+  reservePublicShort,
+  releasePublicShort
+} = require('./utils/youtube-rate-limit');
+const { canUseWindowsSpeech, generateWindowsSpeech } = require('./utils/local-tts');
+const {
+  createCartoonIllustrations,
+  getPalette
+} = require('./utils/cartoon-illustrations');
+
+const ROOT = __dirname;
+const DEFAULT_BATCH_DIR = path.join(ROOT, 'data', 'short-batch-cartoon');
+const LEGACY_BATCH_DIR = path.join(ROOT, 'data', 'short-batch');
+const DEFAULT_FLOW_IMAGE_DIR = path.resolve(
+  ROOT,
+  process.env.FLOW_IMAGE_DIR || path.join('data', 'finance-sample', 'flow-images')
+);
+const MAX_COUNT = 20;
+const VISUAL_BEATS_COUNT = 12;
+const VISUAL_STYLE = 'local cartoon illustrations';
+const RENDER_VERSION = 'cartoon-illustrations-v1';
+const CATEGORY_ID = String(process.env.YOUTUBE_CATEGORY_ID || '27');
+const EXPECTED_CHANNEL = process.env.CHANNEL_NAME || 'Nature Lover 2000';
+const DEFAULT_UPLOAD_DELAY_MS = Number(process.env.SHORT_BATCH_UPLOAD_DELAY_MS || process.env.DEFAULT_DELAY_BETWEEN_POSTS || 15000);
+const DISCLAIMER = 'This is general financial education, not personalized financial advice. Returns are not guaranteed. Fees, taxes, inflation, risk, and individual circumstances can affect outcomes.';
+
+const TOPIC_DEFINITIONS = [
+  {
+    key: 'emergency-fund',
+    title: 'Why an Emergency Fund Comes Before Investing',
+    source: 'https://www.consumerfinance.gov/consumer-tools/savings-goal-calculator/',
+    body: 'An emergency fund is cash set aside for unexpected costs such as a repair, medical bill, or loss of income. A practical starting point is a small target you can reach, followed by a review of essential monthly expenses. Keeping this money accessible can reduce the need to use expensive debt when life changes. The right amount depends on income stability, household needs, insurance, and available support. A savings account is different from a long-term investment because the priority here is access and stability, not chasing market growth.'
+  },
+  {
+    key: 'compound-interest',
+    title: 'Compound Interest: Time Changes the Math',
+    source: 'https://www.investor.gov/financial-tools-calculators/calculators/compound-interest-calculator',
+    body: 'Compound interest means that interest or investment growth can be added to a balance, allowing later growth to apply to the larger balance. A hypothetical example can show why time and regular contributions matter. But an assumed rate is only an assumption. Investment values can fall, contributions can change, and fees and taxes can reduce results. The useful lesson is to test several assumptions and understand the math rather than treating an illustration as a forecast.'
+  },
+  {
+    key: 'apr-versus-apy',
+    title: 'APR and APY Are Not the Same Number',
+    source: 'https://www.consumerfinance.gov/ask-cfpb/what-is-the-difference-between-an-apr-and-an-apy-en-126/',
+    body: 'APR and APY describe different parts of borrowing and saving costs. Annual percentage rate, or APR, is commonly used to compare borrowing costs and may include certain fees. Annual percentage yield, or APY, reflects the effect of compounding on a deposit account. When comparing products, check the account terms, compounding schedule, fees, and whether the rate is fixed or variable. A larger-looking number is not automatically the better deal without knowing what it measures.'
+  },
+  {
+    key: 'diversification',
+    title: 'Diversification Reduces Single-Asset Risk',
+    source: 'https://www.investor.gov/introduction-investing/investing-basics/glossary/diversification',
+    body: 'Diversification means spreading money across different investments instead of relying on one company, sector, or asset. It can reduce the effect of one holding performing badly, although it cannot remove market risk or guarantee a profit. Diversification should match the time horizon and risk tolerance of the goal. A broad fund may hold many securities, but investors should still review what it owns, its fees, and how closely it fits the intended allocation.'
+  },
+  {
+    key: 'dollar-cost-averaging',
+    title: 'What Dollar-Cost Averaging Actually Does',
+    source: 'https://www.investor.gov/introduction-investing/investing-basics/glossary/dollar-cost-averaging',
+    body: 'Dollar-cost averaging is investing equal amounts at regular intervals, regardless of market price. That approach buys more shares when prices are lower and fewer when prices are higher. It can make a routine easier to follow and reduce the pressure to choose one entry date. It does not guarantee a profit, prevent losses, or prove better than investing a lump sum when cash is already available. The method should be considered alongside fees, taxes, and the goal timeline.'
+  },
+  {
+    key: 'credit-utilization',
+    title: 'Credit Utilization Is One Part of Credit Health',
+    source: 'https://www.consumerfinance.gov/ask-cfpb/what-is-credit-utilization-and-how-does-it-affect-my-credit-score-en-413/',
+    body: 'Credit utilization compares reported revolving balances with available credit limits. Lower utilization is often viewed favorably by scoring models, but there is no single magic percentage that guarantees a particular score. Payment history, account age, new applications, and credit mix can also matter. Paying a balance in full can avoid interest, but the reported balance depends on issuer timing. Check statements and credit reports, and do not borrow money simply to manipulate a score.'
+  },
+  {
+    key: 'payment-history',
+    title: 'Why On-Time Payments Matter',
+    source: 'https://www.consumerfinance.gov/consumer-tools/credit-reports-and-scores/',
+    body: 'Payment history is an important part of many credit-scoring systems. Missing a required payment can lead to fees, interest, account actions, and possible credit-reporting consequences. A simple system can help: list due dates, use reminders, and choose autopay for at least a manageable minimum when appropriate. Autopay is not a substitute for checking the account balance and statement. Different lenders and scoring models use different information, so a single action cannot guarantee a score change.'
+  },
+  {
+    key: 'inflation',
+    title: 'Inflation Changes Purchasing Power',
+    source: 'https://www.bls.gov/cpi/',
+    body: 'Inflation is a general increase in prices over time, which means a fixed amount of money may buy fewer goods and services later. The Consumer Price Index is one measure of average price changes, not a personal forecast for every household. When planning a goal, compare expected costs, income, savings, and the time horizon. Cash can offer stability and access, while investments introduce risk. The right balance depends on when the money is needed and how much loss can be tolerated.'
+  },
+  {
+    key: 'investment-fees',
+    title: 'Small Investment Fees Can Compound Too',
+    source: 'https://www.investor.gov/introduction-investing/getting-started/fees-and-expenses',
+    body: 'Investment fees can include expense ratios, transaction costs, account fees, or advisory charges. A fee that looks small can reduce the balance available to grow over a long period. Compare the total cost, services, investment approach, and tax treatment rather than looking at one percentage in isolation. Lower cost does not automatically mean better for every investor, but understanding the fee lets you compare more honestly. Ask for a clear explanation of how and when each charge is applied.'
+  },
+  {
+    key: 'employer-match',
+    title: 'How to Understand an Employer Match',
+    source: 'https://www.dol.gov/general/topic/retirement/401k',
+    body: 'Some workplace retirement plans contribute additional money when an employee contributes, subject to plan rules. Read the plan document for the match formula, contribution limits, vesting schedule, eligible pay, and investment choices. A match can be an important benefit, but it is not a reason to ignore high-interest debt or an emergency reserve. Contributions are invested according to the selected options and can lose value. Review the rules with the plan administrator before making a decision.'
+  },
+  {
+    key: 'roth-traditional',
+    title: 'Roth and Traditional Retirement Accounts',
+    source: 'https://www.irs.gov/retirement-plans/roth-comparison-chart',
+    body: 'Traditional and Roth retirement accounts generally differ in when taxes are applied. Traditional contributions may receive tax treatment now and withdrawals may be taxable later, subject to rules. Roth contributions are generally made with after-tax money and qualified withdrawals may be tax-free. Eligibility, limits, deductions, employer plans, and future tax circumstances matter. The label alone does not identify the best choice. Check current IRS rules and consider professional guidance for a personal decision.'
+  },
+  {
+    key: 'bond-prices',
+    title: 'Why Bond Prices Can Move When Rates Change',
+    source: 'https://www.investor.gov/introduction-investing/investing-basics/investment-products/bonds-or-fixed-income-products',
+    body: 'A bond is a debt investment with terms that can include interest payments and a maturity date. When market interest rates change, the price of an existing bond can move because its fixed payments look more or less attractive compared with new bonds. A bond fund has its own price and interest-rate exposure, and it does not have the same maturity promise as an individual bond. Credit risk, inflation, liquidity, and fees also matter. Bonds are not automatically risk-free.'
+  },
+  {
+    key: 'saving-versus-investing',
+    title: 'Saving and Investing Serve Different Timelines',
+    source: 'https://www.investor.gov/introduction-investing/investing-basics',
+    body: 'Saving usually emphasizes access and preserving money for nearer-term needs. Investing generally accepts more uncertainty in pursuit of long-term growth. Money needed soon may not have enough time to recover from a market decline, while money for a distant goal may face purchasing-power risk if it never grows. Separate goals by timeline, build a cash reserve, and understand the possible loss before choosing an account or investment. There is no universal allocation that fits every household.'
+  },
+  {
+    key: 'needs-wants-budget',
+    title: 'A Budget Turns Spending Into a Plan',
+    source: 'https://www.consumerfinance.gov/consumer-tools/budgeting/',
+    body: 'A budget is a plan for expected income and spending, not a test of willpower. Start with take-home income, fixed bills, variable essentials, debt payments, savings goals, and flexible spending. Review several months of actual transactions so irregular costs do not disappear from the plan. A useful budget leaves room for adjustments and realistic priorities. Cutting every enjoyable purchase may not be sustainable. The goal is awareness and control, not a perfect number that never changes.'
+  },
+  {
+    key: 'sinking-funds',
+    title: 'Sinking Funds Make Irregular Bills Predictable',
+    source: 'https://www.consumerfinance.gov/consumer-tools/saving-goals/',
+    body: 'A sinking fund sets aside money over time for a known future expense such as insurance, gifts, tuition, or car maintenance. Estimate the bill, divide it across the months before it is due, and keep the money separate enough to see its purpose. Estimates can be wrong, so review the balance and update the monthly amount. A sinking fund is not an emergency fund and does not make an unaffordable expense affordable by itself. It is a planning tool for costs you can reasonably anticipate.'
+  },
+  {
+    key: 'debt-payoff-methods',
+    title: 'Debt Avalanche and Debt Snowball',
+    source: 'https://www.consumerfinance.gov/ask-cfpb/what-is-the-debt-avalanche-method-en-1057/',
+    body: 'The debt avalanche method sends extra money toward the highest interest rate while paying required minimums elsewhere. The debt snowball method targets the smallest balance first to create quick milestones. Both methods can work if minimum payments remain current and the plan is sustainable. The avalanche may reduce interest mathematically, while the snowball can provide motivation. Compare rates, fees, cash flow, and behavior rather than treating one method as a guarantee of success.'
+  },
+  {
+    key: 'simple-versus-compound',
+    title: 'Simple Interest Versus Compound Interest',
+    source: 'https://www.investor.gov/financial-tools-calculators/calculators/compound-interest-calculator',
+    body: 'Simple interest is calculated on the original principal under the stated terms. Compound interest calculates later interest on a balance that can include previously credited interest. Real products can use daily, monthly, or other schedules, and fees or withdrawals change the math. Before comparing offers, check the annual rate, compounding frequency, balance rules, and penalties. A calculator can illustrate the difference, but the result is only as reliable as the assumptions entered.'
+  },
+  {
+    key: 'net-worth',
+    title: 'Net Worth Is a Snapshot, Not a Score',
+    source: 'https://www.consumerfinance.gov/consumer-tools/educator-tools/youth-financial-education/financial-well-being/',
+    body: 'Net worth is the value of what you own minus what you owe at a point in time. Listing cash, investments, property, loans, and credit balances can show the direction of a plan more clearly than income alone. Values can change, estimates can be imperfect, and a single month is not a verdict on financial health. Track it periodically, use consistent definitions, and pair the snapshot with cash flow, goals, insurance, and the ability to handle emergencies.'
+  },
+  {
+    key: 'tax-withholding',
+    title: 'Tax Withholding Is Not Your Final Tax Bill',
+    source: 'https://www.irs.gov/individuals/understanding-your-irs-notice-or-letter',
+    body: 'Tax withholding is money sent from pay or certain payments toward an eventual tax obligation. The final amount depends on income, deductions, credits, filing status, and current tax rules. A refund may mean more was withheld than needed, while a balance due can mean withholding was too low; neither result alone measures financial success. Review pay stubs and the official withholding estimator when circumstances change. Keep records and use a qualified tax professional for personal questions.'
+  },
+  {
+    key: 'financial-scams',
+    title: 'Three Checks Before Trusting a Money Offer',
+    source: 'https://www.consumerfinance.gov/consumer-tools/fraud/',
+    body: 'Be cautious when a money offer demands urgency, secrecy, upfront payment, or promises unusually easy profits. Verify the person and company independently, read the terms, and do not share passwords or one-time security codes. Search for official contact details instead of using a link in an unexpected message. A polished website or testimonial is not proof. Pause when pressure rises and report suspected fraud through the appropriate official channel. Protecting money often starts with slowing down.'
+  }
+];
+
+const FINANCE_TOPICS = TOPIC_DEFINITIONS.map((topic, index) => ({
+  ...topic,
+  index: index + 1,
+  isShort: true,
+  contentType: 'short',
+  aspectRatio: '9:16',
+  script: `${topic.body}\n\n${DISCLAIMER}`,
+  tags: ['Shorts', 'personal finance', 'financial literacy', 'money basics', topic.key]
+}));
+
+const VISUAL_PLANS = {
+  'emergency-fund': [
+    { title: 'Repair bill', detail: 'A broken appliance can arrive without warning', kind: 'receipt' },
+    { title: 'Medical expense', detail: 'An urgent bill can hit the monthly plan', kind: 'receipt' },
+    { title: 'Income gap', detail: 'A pause in income makes accessible cash valuable', kind: 'clock' },
+    { title: 'First target', detail: 'Choose a savings milestone you can reach', kind: 'target' },
+    { title: 'Cash cushion', detail: 'Keep reserve money liquid and separate', kind: 'jar' },
+    { title: 'Essential costs', detail: 'List housing food utilities and transport', kind: 'house' },
+    { title: 'Monthly deposits', detail: 'Build the target with repeat contributions', kind: 'calendar' },
+    { title: 'Debt detour', detail: 'Cash can reduce reliance on expensive debt', kind: 'credit-card' },
+    { title: 'Coverage check', detail: 'Insurance and support change the target', kind: 'shield' },
+    { title: 'Refill the reserve', detail: 'Review the balance after a withdrawal', kind: 'chart' },
+    { title: 'Access test', detail: 'Know where the reserve is held', kind: 'lock' },
+    { title: 'Steady foundation', detail: 'Start with stability before chasing growth', kind: 'cash' }
+  ],
+  'compound-interest': [
+    { title: 'Starting balance', detail: 'Growth begins with the amount already saved', kind: 'cash' },
+    { title: 'Interest is added', detail: 'Credited interest can join the balance', kind: 'coins' },
+    { title: 'Growth on growth', detail: 'Later growth can apply to earlier growth', kind: 'chart' },
+    { title: 'Time does work', detail: 'A longer horizon changes the math', kind: 'clock' },
+    { title: 'Regular contributions', detail: 'New deposits can add another growth base', kind: 'calendar' },
+    { title: 'Reinvested earnings', detail: 'Leaving earnings invested changes the curve', kind: 'jar' },
+    { title: 'Assumed rate', detail: 'A hypothetical rate is not a promise', kind: 'target' },
+    { title: 'Slow beginning', detail: 'Early progress can look modest', kind: 'ladder' },
+    { title: 'Later acceleration', detail: 'The balance can grow faster on a larger base', kind: 'chart' },
+    { title: 'Fees and taxes', detail: 'Costs can reduce the amount left to grow', kind: 'receipt' },
+    { title: 'Down years', detail: 'Investment values can fall along the way', kind: 'warning' },
+    { title: 'Test scenarios', detail: 'Compare several assumptions before deciding', kind: 'scale' }
+  ],
+  'apr-versus-apy': [
+    { title: 'Borrowing cost', detail: 'APR commonly helps compare borrowing costs', kind: 'credit-card' },
+    { title: 'Deposit yield', detail: 'APY describes the effect of compounding', kind: 'jar' },
+    { title: 'APR label', detail: 'Check what fees the stated rate includes', kind: 'receipt' },
+    { title: 'APY compounds', detail: 'The yield reflects a compounding schedule', kind: 'chart' },
+    { title: 'Terms matter', detail: 'A rate is only one part of the product', kind: 'document' },
+    { title: 'Schedule check', detail: 'Daily monthly and other schedules differ', kind: 'calendar' },
+    { title: 'Fixed or variable', detail: 'A rate can stay put or change over time', kind: 'scale' },
+    { title: 'Compare like with like', detail: 'Use the same measure for a fair comparison', kind: 'scale' },
+    { title: 'Bigger is not always better', detail: 'A larger number needs context', kind: 'warning' },
+    { title: 'Account access', detail: 'Withdrawal rules can affect the real value', kind: 'lock' },
+    { title: 'Read the terms', detail: 'Look for fees limits and conditions', kind: 'receipt' },
+    { title: 'Choose the measure', detail: 'Match APR or APY to the decision', kind: 'target' }
+  ],
+  diversification: [
+    { title: 'Single holding', detail: 'One company can dominate the outcome', kind: 'warning' },
+    { title: 'Asset buckets', detail: 'Spread exposure across different assets', kind: 'bucket' },
+    { title: 'Stock slice', detail: 'Company ownership brings market movement', kind: 'chart' },
+    { title: 'Bond slice', detail: 'Debt investments have their own risks', kind: 'document' },
+    { title: 'Sector spread', detail: 'Different industries may behave differently', kind: 'scale' },
+    { title: 'Broad fund', detail: 'A fund may hold many securities', kind: 'jar' },
+    { title: 'Allocation target', detail: 'Choose a mix for the goal and horizon', kind: 'target' },
+    { title: 'Market drop', detail: 'Diversification cannot remove market losses', kind: 'chart' },
+    { title: 'Company risk', detail: 'One weak holding has less control in a mix', kind: 'shield' },
+    { title: 'Time horizon', detail: 'The right mix depends on when money is needed', kind: 'clock' },
+    { title: 'Review holdings', detail: 'Check what a fund actually owns', kind: 'document' },
+    { title: 'Risk remains', detail: 'Spreading money never guarantees a profit', kind: 'warning' }
+  ],
+  'dollar-cost-averaging': [
+    { title: 'Scheduled deposit', detail: 'Invest a planned amount at regular intervals', kind: 'calendar' },
+    { title: 'Equal amount', detail: 'The contribution stays consistent by design', kind: 'cash' },
+    { title: 'High price', detail: 'The same dollars buy fewer shares', kind: 'chart' },
+    { title: 'Low price', detail: 'The same dollars buy more shares', kind: 'chart' },
+    { title: 'More shares', detail: 'Lower prices can increase the share count', kind: 'coins' },
+    { title: 'Fewer shares', detail: 'Higher prices can reduce the share count', kind: 'coins' },
+    { title: 'Routine transfer', detail: 'A system can remove one timing decision', kind: 'clock' },
+    { title: 'One-date pressure', detail: 'The method avoids choosing one entry day', kind: 'warning' },
+    { title: 'Losses still happen', detail: 'Regular investing does not prevent losses', kind: 'warning' },
+    { title: 'Fees and taxes', detail: 'Costs still affect each contribution', kind: 'receipt' },
+    { title: 'Goal timeline', detail: 'Match the routine to when money is needed', kind: 'target' },
+    { title: 'Check the method', detail: 'Compare it with a lump sum when relevant', kind: 'scale' }
+  ],
+  'credit-utilization': [
+    { title: 'Credit limit', detail: 'Available revolving credit sets the ceiling', kind: 'credit-card' },
+    { title: 'Reported balance', detail: 'The issuer may report a balance snapshot', kind: 'receipt' },
+    { title: 'Utilization ratio', detail: 'Balance divided by limit creates the ratio', kind: 'scale' },
+    { title: 'Lower ratio', detail: 'A smaller reported balance is often viewed favorably', kind: 'chart' },
+    { title: 'Statement date', detail: 'Timing affects which balance gets reported', kind: 'calendar' },
+    { title: 'Available room', detail: 'Unused limit is not a reason to borrow', kind: 'jar' },
+    { title: 'No magic percentage', detail: 'No single number guarantees a score', kind: 'warning' },
+    { title: 'Pay in full', detail: 'Full payment can help avoid interest', kind: 'shield' },
+    { title: 'Interest cost', detail: 'Do not carry debt just to shape a score', kind: 'cash' },
+    { title: 'Account age', detail: 'Credit health includes history over time', kind: 'clock' },
+    { title: 'New applications', detail: 'Recent applications can also matter', kind: 'document' },
+    { title: 'Review the report', detail: 'Check statements and reports for errors', kind: 'target' }
+  ],
+  'payment-history': [
+    { title: 'Due date', detail: 'Put every required payment on a calendar', kind: 'calendar' },
+    { title: 'Required minimum', detail: 'Keep the minimum current when appropriate', kind: 'receipt' },
+    { title: 'Reminder', detail: 'A simple alert can protect the routine', kind: 'clock' },
+    { title: 'Autopay setting', detail: 'Automate a manageable payment if useful', kind: 'credit-card' },
+    { title: 'Account balance', detail: 'Autopay is not a substitute for checking cash', kind: 'jar' },
+    { title: 'Missed payment', detail: 'Late action can create fees and consequences', kind: 'warning' },
+    { title: 'Fees and interest', detail: 'A missed date can make debt more expensive', kind: 'chart' },
+    { title: 'Credit reporting', detail: 'Payment data may reach a credit report', kind: 'document' },
+    { title: 'Scoring models', detail: 'Different models use different information', kind: 'scale' },
+    { title: 'Check the statement', detail: 'Confirm the payment posted correctly', kind: 'receipt' },
+    { title: 'Keep a buffer', detail: 'Leave room for timing and account changes', kind: 'shield' },
+    { title: 'Repeat on time', detail: 'A reliable system beats a last-minute scramble', kind: 'target' }
+  ],
+  inflation: [
+    { title: 'Price tag', detail: 'The same item can cost more later', kind: 'receipt' },
+    { title: 'Purchasing power', detail: 'A fixed dollar amount may buy less', kind: 'cash' },
+    { title: 'Grocery basket', detail: 'Household price changes are not identical', kind: 'bucket' },
+    { title: 'CPI snapshot', detail: 'An index measures average price movement', kind: 'chart' },
+    { title: 'Future cost', detail: 'Time changes what a goal may require', kind: 'clock' },
+    { title: 'Income comparison', detail: 'Compare costs with income and savings', kind: 'scale' },
+    { title: 'Cash stability', detail: 'Cash can offer access for near-term needs', kind: 'jar' },
+    { title: 'Investment uncertainty', detail: 'Growth options also introduce risk', kind: 'warning' },
+    { title: 'Goal timeline', detail: 'The deadline helps shape the plan', kind: 'calendar' },
+    { title: 'Household differences', detail: 'Average inflation is not a personal forecast', kind: 'people' },
+    { title: 'Scenario check', detail: 'Test more than one cost assumption', kind: 'chart' },
+    { title: 'Balance the plan', detail: 'Access growth and risk must fit the goal', kind: 'target' }
+  ],
+  'investment-fees': [
+    { title: 'Expense ratio', detail: 'A fund cost reduces the balance over time', kind: 'receipt' },
+    { title: 'Trading charge', detail: 'Transaction costs can reduce each move', kind: 'credit-card' },
+    { title: 'Account fee', detail: 'Some accounts charge for access or service', kind: 'document' },
+    { title: 'Advice charge', detail: 'Compare the service with the total cost', kind: 'people' },
+    { title: 'Small percentage', detail: 'A small rate can matter over a long horizon', kind: 'scale' },
+    { title: 'Long horizon', detail: 'Time gives costs more chances to compound', kind: 'clock' },
+    { title: 'Less left to grow', detail: 'Every charge leaves less money invested', kind: 'chart' },
+    { title: 'Compare the service', detail: 'Lower cost is not the only question', kind: 'people' },
+    { title: 'Tax treatment', detail: 'Taxes can change the cost comparison', kind: 'tax' },
+    { title: 'Charge timing', detail: 'Know when and how each fee is applied', kind: 'calendar' },
+    { title: 'Ask what is included', detail: 'Request a clear explanation of charges', kind: 'warning' },
+    { title: 'Total cost', detail: 'Compare the whole price instead of one number', kind: 'target' }
+  ],
+  'employer-match': [
+    { title: 'Paycheck contribution', detail: 'An employee contribution starts the process', kind: 'cash' },
+    { title: 'Employee deposit', detail: 'Read how much the plan accepts', kind: 'jar' },
+    { title: 'Employer add-on', detail: 'The plan may contribute extra money', kind: 'people' },
+    { title: 'Match formula', detail: 'The formula determines how the benefit works', kind: 'scale' },
+    { title: 'Contribution limit', detail: 'Annual limits can restrict the amount', kind: 'document' },
+    { title: 'Vesting schedule', detail: 'Some employer money takes time to vest', kind: 'calendar' },
+    { title: 'Eligible pay', detail: 'The plan rules define which pay counts', kind: 'receipt' },
+    { title: 'Investment menu', detail: 'Contributions use the options you select', kind: 'chart' },
+    { title: 'Market value', detail: 'Invested balances can lose value', kind: 'warning' },
+    { title: 'Emergency reserve', detail: 'A match is not a substitute for cash reserves', kind: 'shield' },
+    { title: 'High-interest debt', detail: 'Consider expensive debt in the full plan', kind: 'credit-card' },
+    { title: 'Read the plan', detail: 'Confirm rules with the plan administrator', kind: 'target' }
+  ],
+  'roth-traditional': [
+    { title: 'Traditional account', detail: 'Tax treatment may happen partly up front', kind: 'document' },
+    { title: 'Roth account', detail: 'Contributions are generally after tax', kind: 'jar' },
+    { title: 'Tax treatment now', detail: 'Current deductions depend on the rules', kind: 'tax' },
+    { title: 'Tax treatment later', detail: 'Future withdrawals have conditions', kind: 'calendar' },
+    { title: 'Qualified withdrawal', detail: 'Account rules define when benefits apply', kind: 'shield' },
+    { title: 'Eligibility limits', detail: 'Income and contribution limits can matter', kind: 'scale' },
+    { title: 'Employer plan', detail: 'Workplace options add another layer of rules', kind: 'people' },
+    { title: 'Deduction question', detail: 'A label alone does not answer tax treatment', kind: 'receipt' },
+    { title: 'Future rules uncertain', detail: 'Future tax circumstances are not known', kind: 'warning' },
+    { title: 'Investment options', detail: 'The account still holds chosen investments', kind: 'chart' },
+    { title: 'Current rules', detail: 'Check the latest official guidance', kind: 'document' },
+    { title: 'Personal fit', detail: 'The better choice depends on circumstances', kind: 'target' }
+  ],
+  'bond-prices': [
+    { title: 'Bond contract', detail: 'A bond has terms for payments and maturity', kind: 'document' },
+    { title: 'Fixed payment', detail: 'The stated payment can stay fixed', kind: 'cash' },
+    { title: 'Rates rise', detail: 'New bonds can offer more attractive rates', kind: 'chart' },
+    { title: 'Existing price falls', detail: 'Older fixed payments may look less attractive', kind: 'warning' },
+    { title: 'New bond comparison', detail: 'Price and yield move together in the market', kind: 'scale' },
+    { title: 'Rates move down', detail: 'Existing payments can look more attractive', kind: 'chart' },
+    { title: 'Maturity date', detail: 'An individual bond has a stated end date', kind: 'calendar' },
+    { title: 'Bond fund', detail: 'A fund has its own price and rate exposure', kind: 'bucket' },
+    { title: 'Different maturity', detail: 'A fund does not make one maturity promise', kind: 'clock' },
+    { title: 'Credit risk', detail: 'The issuer may not meet every obligation', kind: 'shield' },
+    { title: 'Inflation risk', detail: 'Future payments may buy less than expected', kind: 'receipt' },
+    { title: 'Fees and liquidity', detail: 'Costs and trading access also matter', kind: 'target' }
+  ],
+  'saving-versus-investing': [
+    { title: 'Near-term need', detail: 'Sooner goals usually prioritize access', kind: 'calendar' },
+    { title: 'Cash reserve', detail: 'Savings can preserve money for planned needs', kind: 'jar' },
+    { title: 'Easy access', detail: 'A reserve should be available when needed', kind: 'lock' },
+    { title: 'Long horizon', detail: 'Distant goals may have time for uncertainty', kind: 'clock' },
+    { title: 'Growth possibility', detail: 'Investing accepts risk for possible growth', kind: 'chart' },
+    { title: 'Market decline', detail: 'Investments can be worth less at the wrong time', kind: 'warning' },
+    { title: 'Recovery time', detail: 'A longer horizon may allow more recovery time', kind: 'ladder' },
+    { title: 'Purchasing power', detail: 'Cash that never grows can lose buying power', kind: 'cash' },
+    { title: 'Goal buckets', detail: 'Separate money by purpose and deadline', kind: 'bucket' },
+    { title: 'Risk tolerance', detail: 'The possible loss must be acceptable', kind: 'scale' },
+    { title: 'Separate accounts', detail: 'Keep near and long-term jobs visible', kind: 'house' },
+    { title: 'Match the timeline', detail: 'Choose the tool after choosing the date', kind: 'target' }
+  ],
+  'needs-wants-budget': [
+    { title: 'Take-home income', detail: 'Start with money that actually arrives', kind: 'cash' },
+    { title: 'Fixed bills', detail: 'Housing and recurring bills anchor the plan', kind: 'house' },
+    { title: 'Variable essentials', detail: 'Food and transport can change month to month', kind: 'receipt' },
+    { title: 'Debt payment', detail: 'Required debt payments belong in the plan', kind: 'credit-card' },
+    { title: 'Savings goal', detail: 'Give saving a visible job and amount', kind: 'jar' },
+    { title: 'Flexible spending', detail: 'A useful budget leaves room for real life', kind: 'people' },
+    { title: 'Review transactions', detail: 'Actual history reveals what estimates miss', kind: 'document' },
+    { title: 'Irregular costs', detail: 'Annual bills should not disappear from view', kind: 'calendar' },
+    { title: 'Needs versus wants', detail: 'Categories make tradeoffs easier to see', kind: 'scale' },
+    { title: 'Adjust the plan', detail: 'A budget should change when facts change', kind: 'chart' },
+    { title: 'Realistic priorities', detail: 'Sustainable choices beat perfect guesses', kind: 'target' },
+    { title: 'Sustainable routine', detail: 'Review and revise instead of starting over', kind: 'clock' }
+  ],
+  'sinking-funds': [
+    { title: 'Known future bill', detail: 'Plan ahead for a cost you can anticipate', kind: 'receipt' },
+    { title: 'Insurance due', detail: 'A predictable premium can use a dedicated fund', kind: 'shield' },
+    { title: 'Gifts and events', detail: 'Seasonal spending is easier when expected', kind: 'people' },
+    { title: 'Tuition date', detail: 'A deadline tells you how much time remains', kind: 'document' },
+    { title: 'Car maintenance', detail: 'Planned upkeep is not the same as a surprise', kind: 'house' },
+    { title: 'Estimate total', detail: 'Start with a reasonable cost estimate', kind: 'scale' },
+    { title: 'Divide by months', detail: 'Spread the target across the months left', kind: 'calendar' },
+    { title: 'Separate bucket', detail: 'A visible purpose keeps the money organized', kind: 'bucket' },
+    { title: 'Balance visible', detail: 'Track progress toward the upcoming bill', kind: 'chart' },
+    { title: 'Estimate can change', detail: 'Update the amount when the facts change', kind: 'warning' },
+    { title: 'Not an emergency', detail: 'A planned fund serves a different job', kind: 'jar' },
+    { title: 'Monthly review', detail: 'Check the balance and adjust the deposit', kind: 'clock' }
+  ],
+  'debt-payoff-methods': [
+    { title: 'List every balance', detail: 'Write down rates balances and minimums', kind: 'document' },
+    { title: 'Minimum payments', detail: 'Keep required payments current first', kind: 'receipt' },
+    { title: 'Highest rate', detail: 'The avalanche targets the costliest debt', kind: 'chart' },
+    { title: 'Avalanche path', detail: 'Extra cash moves toward the highest rate', kind: 'ladder' },
+    { title: 'Smallest balance', detail: 'The snowball starts with a quick milestone', kind: 'target' },
+    { title: 'Snowball milestone', detail: 'Visible progress can help motivation', kind: 'coins' },
+    { title: 'Extra cash', detail: 'Direct a sustainable amount beyond minimums', kind: 'cash' },
+    { title: 'Keep current', detail: 'Neither method works without required payments', kind: 'calendar' },
+    { title: 'Interest comparison', detail: 'Compare the mathematical cost of each route', kind: 'scale' },
+    { title: 'Fees and cash flow', detail: 'A plan must fit the money available each month', kind: 'warning' },
+    { title: 'Motivation matters', detail: 'Behavior can affect which method lasts', kind: 'people' },
+    { title: 'Sustainable route', detail: 'Choose a plan you can keep following', kind: 'shield' }
+  ],
+  'simple-versus-compound': [
+    { title: 'Original principal', detail: 'Simple interest starts from the original amount', kind: 'cash' },
+    { title: 'Simple formula', detail: 'The stated terms determine the calculation', kind: 'document' },
+    { title: 'Interest schedule', detail: 'Check when interest is credited', kind: 'calendar' },
+    { title: 'Compound balance', detail: 'Later interest can use a larger balance', kind: 'chart' },
+    { title: 'Interest on interest', detail: 'Earlier credits can join the base', kind: 'coins' },
+    { title: 'Daily crediting', detail: 'Some products calculate on a daily schedule', kind: 'clock' },
+    { title: 'Monthly crediting', detail: 'Other products use a different schedule', kind: 'calendar' },
+    { title: 'Withdrawals change math', detail: 'Removing money changes future growth', kind: 'warning' },
+    { title: 'Fees reduce growth', detail: 'Charges can change the final balance', kind: 'receipt' },
+    { title: 'Penalties matter', detail: 'Check the cost of changing the plan', kind: 'credit-card' },
+    { title: 'Compare assumptions', detail: 'Use the same inputs for a fair example', kind: 'scale' },
+    { title: 'Calculator result', detail: 'An illustration is only as good as its inputs', kind: 'target' }
+  ],
+  'net-worth': [
+    { title: 'List your assets', detail: 'Start with what you own at a point in time', kind: 'house' },
+    { title: 'Cash on hand', detail: 'Include accessible balances consistently', kind: 'cash' },
+    { title: 'Investments', detail: 'Market values can change between snapshots', kind: 'chart' },
+    { title: 'Property estimate', detail: 'Use a consistent method for property values', kind: 'house' },
+    { title: 'Loan balance', detail: 'Debt belongs on the other side of the list', kind: 'credit-card' },
+    { title: 'Credit balance', detail: 'Include revolving debt you still owe', kind: 'receipt' },
+    { title: 'Subtract what is owed', detail: 'Net worth is assets minus liabilities', kind: 'scale' },
+    { title: 'Snapshot date', detail: 'The result describes one moment in time', kind: 'clock' },
+    { title: 'Values can move', detail: 'A single month is not a verdict', kind: 'warning' },
+    { title: 'Consistent definitions', detail: 'Use the same categories each time', kind: 'document' },
+    { title: 'Pair with cash flow', detail: 'The snapshot needs context from daily money', kind: 'people' },
+    { title: 'Track direction', detail: 'Periodic snapshots can show a trend', kind: 'target' }
+  ],
+  'tax-withholding': [
+    { title: 'Paycheck', detail: 'Withholding is taken from pay or some payments', kind: 'cash' },
+    { title: 'Withholding line', detail: 'The amount sent in is not the final bill', kind: 'tax' },
+    { title: 'Estimated obligation', detail: 'The eventual amount depends on current rules', kind: 'document' },
+    { title: 'Filing status', detail: 'Household and filing details affect the result', kind: 'people' },
+    { title: 'Deductions', detail: 'Eligible deductions can change taxable income', kind: 'receipt' },
+    { title: 'Credits', detail: 'Credits can affect the final calculation', kind: 'target' },
+    { title: 'Refund', detail: 'A refund can mean more was withheld than needed', kind: 'jar' },
+    { title: 'Balance due', detail: 'A payment can mean withholding was too low', kind: 'warning' },
+    { title: 'Pay stub review', detail: 'Check the line when circumstances change', kind: 'calendar' },
+    { title: 'Life changes', detail: 'Income and household changes can alter withholding', kind: 'clock' },
+    { title: 'Official estimator', detail: 'Use the current official calculation tool', kind: 'scale' },
+    { title: 'Keep records', detail: 'Save documents and seek qualified guidance', kind: 'lock' }
+  ],
+  'financial-scams': [
+    { title: 'Urgency pressure', detail: 'A rush can make careful checking harder', kind: 'warning' },
+    { title: 'Secret request', detail: 'Secrecy is a reason to pause and verify', kind: 'lock' },
+    { title: 'Upfront payment', detail: 'Do not pay before independently checking the offer', kind: 'credit-card' },
+    { title: 'Easy profit promise', detail: 'Unusually easy returns deserve skepticism', kind: 'chart' },
+    { title: 'Check the identity', detail: 'Confirm who is contacting you', kind: 'people' },
+    { title: 'Verify independently', detail: 'Use official contact details you find yourself', kind: 'document' },
+    { title: 'Official contact', detail: 'Do not trust a link in an unexpected message', kind: 'receipt' },
+    { title: 'Terms before trust', detail: 'Read the offer instead of relying on polish', kind: 'target' },
+    { title: 'Password guard', detail: 'Never share passwords or security codes', kind: 'shield' },
+    { title: 'One-time code', detail: 'A real company should not need your private code', kind: 'lock' },
+    { title: 'Report suspected fraud', detail: 'Use the appropriate official reporting channel', kind: 'warning' },
+    { title: 'Slow down', detail: 'Protecting money often starts with a pause', kind: 'clock' }
+  ]
+};
+
+function parseArgs(argv) {
+  const options = {
+    count: 20,
+    upload: false,
+    publicUpload: false,
+    preview: true,
+    allowSilent: false,
+    uploadCaptions: false,
+    skipThumbnails: false,
+    outputDir: DEFAULT_BATCH_DIR,
+    flowImageDir: DEFAULT_FLOW_IMAGE_DIR,
+    help: false
+  };
+  const valueFlags = new Set(['--count', '--output-dir', '--flow-image-dir']);
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    const equalsIndex = argument.indexOf('=');
+    const flag = equalsIndex === -1 ? argument : argument.slice(0, equalsIndex);
+    let value = equalsIndex === -1 ? null : argument.slice(equalsIndex + 1);
+
+    if (flag === '--help' || flag === '-h') {
+      options.help = true;
+    } else if (flag === '--upload') {
+      options.upload = true;
+      options.preview = false;
+    } else if (flag === '--public') {
+      options.publicUpload = true;
+      options.preview = false;
+    } else if (flag === '--preview') {
+      options.preview = true;
+    } else if (flag === '--allow-silent') {
+      options.allowSilent = true;
+    } else if (flag === '--youtube-captions') {
+      options.uploadCaptions = true;
+    } else if (flag === '--skip-thumbnails') {
+      options.skipThumbnails = true;
+    } else if (valueFlags.has(flag)) {
+      if (value === null) {
+        value = argv[index + 1];
+        index += 1;
+      }
+      if (!value || value.startsWith('--')) throw new Error(`A value is required for ${flag}`);
+      if (flag === '--count') options.count = Number(value);
+      if (flag === '--output-dir') options.outputDir = value;
+      if (flag === '--flow-image-dir') options.flowImageDir = value;
+    } else {
+      throw new Error(`Unknown option: ${argument}`);
+    }
+  }
+
+  return options;
+}
+
+function validateOptions(options) {
+  if (!Number.isInteger(options.count) || options.count < 1 || options.count > MAX_COUNT) {
+    throw new Error('--count must be an integer from 1 to 20');
+  }
+  if (options.publicUpload && !options.upload) {
+    throw new Error('--public requires --upload; public uploads are never implicit');
+  }
+  if (options.preview && options.upload) {
+    throw new Error('--preview cannot be combined with --upload');
+  }
+  return options;
+}
+
+function printHelp() {
+  console.log(`Usage:
+  npm run shorts:batch                 Generate 20 local finance Shorts
+  npm run shorts:batch -- --count 5    Generate a smaller local preview batch
+
+Options:
+  --count <1..20>       Number of predefined topics (default: 20)
+  --preview             Generate local files only (default behavior)
+  --upload              Upload generated files; private unless --public is set
+  --public              Required with --upload for public Shorts
+  --allow-silent        Permit an intentional silent preview when TTS fails
+  --youtube-captions    Also upload SRT tracks (burned captions are always included)
+  --skip-thumbnails     Continue uploads when YouTube thumbnail uploads are blocked
+  --flow-image-dir <p>  Optional Flow still directory for thumbnail reference (default: FLOW_IMAGE_DIR)
+  --output-dir <p>      Batch output directory (default: data/short-batch-cartoon)
+  --help                Show this help
+
+Visuals are 12 topic-specific local SVG + Sharp cartoon panels with Ken Burns
+motion, xfade transitions, and burned voice captions. This is cartoon-style 2D
+illustrated motion, not true AI character or object animation; that requires a
+paid or external video model. No Gemini image generation or paid Flow animation
+is used. Review local MP4/SRT files before using --upload --public. Public
+Shorts are capped at 20 per calendar day.
+`);
+}
+
+function slugify(value) {
+  return String(value).toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48);
+}
+
+function resolveFromRoot(value) {
+  return path.resolve(ROOT, value);
+}
+
+async function listFlowImages(flowImageDir) {
+  const entries = await fs.readdir(resolveFromRoot(flowImageDir), { withFileTypes: true });
+  const supported = new Set(['.png', '.jpg', '.jpeg', '.webp']);
+  return entries
+    .filter(entry => entry.isFile() && supported.has(path.extname(entry.name).toLowerCase()))
+    .map(entry => path.join(resolveFromRoot(flowImageDir), entry.name))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function getVisualPlan(topicKey) {
+  const plan = VISUAL_PLANS[topicKey];
+  if (!plan) throw new Error(`No visual plan is defined for topic ${topicKey}`);
+  if (plan.length !== VISUAL_BEATS_COUNT) {
+    throw new Error(`Visual plan for ${topicKey} must contain ${VISUAL_BEATS_COUNT} scenes`);
+  }
+  return plan;
+}
+
+function buildVisualScenes(topic) {
+  return getVisualPlan(topic.key).map((scene, index) => ({
+    ...scene,
+    accent: getPalette(`${topic.key}:${index}`).primary
+  }));
+}
+
+function escapeXml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function wrapTitle(title, maxLength = 24) {
+  const words = String(title).split(/\s+/);
+  const lines = [];
+  let line = '';
+  for (const word of words) {
+    const candidate = line ? `${line} ${word}` : word;
+    if (line && candidate.length > maxLength) {
+      lines.push(line);
+      line = word;
+    } else {
+      line = candidate;
+    }
+  }
+  if (line) lines.push(line);
+  return lines.slice(0, 4);
+}
+
+function thumbnailOverlay(topic) {
+  const titleLines = wrapTitle(topic.title);
+  const titleSvg = titleLines.map((line, index) => (
+    `<tspan x="58" dy="${index === 0 ? 0 : 76}">${escapeXml(line)}</tspan>`
+  )).join('');
+  return `
+    <svg width="1280" height="720" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <linearGradient id="shade" x1="0" y1="0" x2="1" y2="0">
+          <stop offset="0" stop-color="#061323" stop-opacity="0.94"/>
+          <stop offset="0.7" stop-color="#061323" stop-opacity="0.38"/>
+          <stop offset="1" stop-color="#061323" stop-opacity="0.08"/>
+        </linearGradient>
+        <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+          <feDropShadow dx="0" dy="5" stdDeviation="5" flood-color="#000000" flood-opacity="0.75"/>
+        </filter>
+      </defs>
+      <rect width="1280" height="720" fill="url(#shade)"/>
+      <rect x="54" y="48" width="282" height="62" rx="14" fill="#f6c75d"/>
+      <text x="195" y="89" text-anchor="middle" fill="#071522" font-family="Arial, sans-serif" font-size="29px" font-weight="900">FINANCE FACTS</text>
+      <text x="58" y="270" fill="#ffffff" font-family="Arial, sans-serif" font-size="60px" font-weight="900" filter="url(#shadow)">${titleSvg}</text>
+      <text x="58" y="650" fill="#f6c75d" font-family="Arial, sans-serif" font-size="27px" font-weight="700">Educational only | Returns are not guaranteed</text>
+    </svg>`;
+}
+
+async function createLocalThumbnail(sourcePath, topic, outputPath) {
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await sharp(sourcePath)
+    .resize(1280, 720, { fit: 'cover', position: 'centre' })
+    .composite([{ input: Buffer.from(thumbnailOverlay(topic)) }])
+    .jpeg({ quality: 90, progressive: true })
+    .toFile(outputPath);
+  return outputPath;
+}
+
+function buildYouTubeDescription(topic) {
+  return `${topic.script}\n\nSource: ${topic.source}\n\n${DISCLAIMER}\n\n#Shorts #PersonalFinance #FinancialLiteracy`;
+}
+
+function sanitizeTags(tags = []) {
+  const result = [];
+  let total = 0;
+  for (const tag of tags) {
+    const value = String(tag).trim();
+    if (!value || total + value.length + 1 > 500) continue;
+    result.push(value);
+    total += value.length + 1;
+  }
+  return result;
+}
+
+async function readManifest(manifestPath) {
+  try {
+    const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
+    manifest.items ||= {};
+    return manifest;
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error;
+    return { version: 1, status: 'preview', items: {} };
+  }
+}
+
+async function writeJson(filePath, value) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const temporaryPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  await fs.writeFile(temporaryPath, JSON.stringify(value, null, 2), 'utf8');
+  try {
+    await fs.rename(temporaryPath, filePath);
+  } catch {
+    await fs.rm(filePath, { force: true }).catch(() => {});
+    await fs.rename(temporaryPath, filePath);
+  }
+}
+
+async function fileExists(filePath) {
+  try {
+    const stats = await fs.stat(filePath);
+    return stats.isFile() && stats.size > 0;
+  } catch {
+    return false;
+  }
+}
+
+function itemPaths(outputDir, topic) {
+  const itemDir = path.join(outputDir, 'items', `${String(topic.index).padStart(2, '0')}-${slugify(topic.key)}`);
+  return {
+    itemDir,
+    audio: path.join(itemDir, 'narration.mp3'),
+    illustrationsDir: path.join(itemDir, 'illustrations'),
+    cardsDir: path.join(itemDir, 'cards'),
+    video: path.join(itemDir, `${slugify(topic.key)}.mp4`),
+    srt: path.join(itemDir, `${slugify(topic.key)}.srt`),
+    thumbnail: path.join(itemDir, `${slugify(topic.key)}-thumbnail.jpg`)
+  };
+}
+
+async function generatedFilesAreReady(files, expectedIllustrations = VISUAL_BEATS_COUNT) {
+  if (!await fileExists(files.video) || !await fileExists(files.srt) || !await fileExists(files.thumbnail)) {
+    return false;
+  }
+  try {
+    const entries = await fs.readdir(files.illustrationsDir, { withFileTypes: true });
+    return entries.filter(entry => entry.isFile() && path.extname(entry.name).toLowerCase() === '.png').length >= expectedIllustrations;
+  } catch {
+    return false;
+  }
+}
+
+async function createSilentAudio(outputPath, duration) {
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await runFFmpeg([
+    '-y',
+    '-f', 'lavfi',
+    '-i', 'anullsrc=r=24000:cl=mono',
+    '-t', String(duration),
+    '-c:a', 'libmp3lame',
+    '-q:a', '9',
+    outputPath
+  ]);
+  return outputPath;
+}
+
+async function generateNarration(generator, topic, audioPath, allowSilent) {
+  if (await isUsableAudioFile(audioPath)) return { path: audioPath, provider: 'cached narration', silent: false };
+
+  await fs.mkdir(path.dirname(audioPath), { recursive: true });
+  const configuredProvider = process.env.SHORT_BATCH_TTS_PROVIDER || process.env.TTS_PROVIDER;
+  if ((configuredProvider === 'windows' || configuredProvider === 'system') && canUseWindowsSpeech()) {
+    await generateWindowsSpeech(topic.script, audioPath);
+    return { path: audioPath, provider: 'Windows System.Speech', silent: false };
+  }
+  const preferGemini = generator.gemini && (!configuredProvider || configuredProvider === 'auto' || configuredProvider === 'gemini');
+  const previousProvider = process.env.TTS_PROVIDER;
+  if (preferGemini) process.env.TTS_PROVIDER = 'gemini';
+
+  try {
+    const generatedPath = await generator.generateTTSAudio(topic.script, audioPath);
+    if (!await isUsableAudioFile(generatedPath)) {
+      throw new Error('TTS provider returned a simulation or empty audio file');
+    }
+    return { path: generatedPath, provider: 'AIVideoGenerator TTS', silent: false };
+  } catch (error) {
+    let narrationError = error;
+    if (canUseWindowsSpeech()) {
+      try {
+        await generateWindowsSpeech(topic.script, audioPath);
+        return { path: audioPath, provider: 'Windows System.Speech fallback', silent: false };
+      } catch (localError) {
+        narrationError = new Error(`${error.message}; Windows Speech fallback failed: ${localError.message}`);
+      }
+    }
+    if (!allowSilent) {
+      throw new Error(`Narration failed for ${topic.key}; refusing a silent Short: ${narrationError.message}`);
+    }
+    const duration = estimateNarrationDuration(topic.script);
+    await createSilentAudio(audioPath, duration);
+    return { path: audioPath, provider: 'intentional silent preview', silent: true };
+  } finally {
+    if (preferGemini) {
+      if (previousProvider === undefined) delete process.env.TTS_PROVIDER;
+      else process.env.TTS_PROVIDER = previousProvider;
+    }
+  }
+}
+
+async function generateItem(topic, flowImages, generator, options, manifest, manifestPath) {
+  const files = itemPaths(options.outputDir, topic);
+  const scenes = buildVisualScenes(topic);
+  const visualKinds = scenes.map(scene => scene.kind);
+  const checkpoint = manifest.items[topic.key] || {
+    key: topic.key,
+    index: topic.index,
+    title: topic.title,
+    status: 'pending'
+  };
+  const wasCartoonCheckpoint = checkpoint.renderVersion === RENDER_VERSION
+    && checkpoint.visualStyle === VISUAL_STYLE
+    && checkpoint.visualBeats === VISUAL_BEATS_COUNT;
+  if (checkpoint.youtube?.id && !wasCartoonCheckpoint) {
+    throw new Error(`Refusing to mix an older YouTube checkpoint into the ${RENDER_VERSION} render for ${topic.key}`);
+  }
+  checkpoint.files = {
+    video: files.video,
+    srt: files.srt,
+    thumbnail: files.thumbnail,
+    audio: files.audio,
+    illustrations: files.illustrationsDir,
+    cards: files.cardsDir
+  };
+  checkpoint.isShort = true;
+  checkpoint.contentType = 'short';
+  checkpoint.aspectRatio = '9:16';
+  checkpoint.renderVersion = RENDER_VERSION;
+  checkpoint.visualStyle = VISUAL_STYLE;
+  checkpoint.visualKinds = visualKinds;
+  checkpoint.visualBeats = scenes.length;
+  checkpoint.visualPlan = scenes.map(scene => ({
+    title: scene.title,
+    detail: scene.detail,
+    kind: scene.kind
+  }));
+  manifest.items[topic.key] = checkpoint;
+  await writeJson(manifestPath, manifest);
+
+  const canReuse = wasCartoonCheckpoint
+    && await generatedFilesAreReady(files, scenes.length);
+  if (canReuse) {
+    console.log(`Reusing local files for ${topic.key}`);
+    checkpoint.status = checkpoint.youtube ? 'uploaded' : 'generated';
+    delete checkpoint.error;
+    await writeJson(manifestPath, manifest);
+    return { checkpoint, files };
+  }
+
+  try {
+    const narration = await generateNarration(generator, topic, files.audio, options.allowSilent);
+    const illustrationPaths = await createCartoonIllustrations(
+      scenes,
+      files.illustrationsDir,
+      { topicKey: topic.key }
+    );
+    await renderShortVideo({
+      sourceImages: illustrationPaths,
+      scenes,
+      narrationText: topic.script,
+      audioPath: narration.path,
+      outputPath: files.video,
+      srtPath: files.srt,
+      cardsDir: files.cardsDir,
+      allowSilent: options.allowSilent,
+      captionMaxWords: 6,
+      fadeDuration: 0.45
+    });
+    const thumbnailSource = illustrationPaths[0] || flowImages[topic.index % flowImages.length];
+    await createLocalThumbnail(thumbnailSource, topic, files.thumbnail);
+    checkpoint.status = 'generated';
+    delete checkpoint.error;
+    checkpoint.silentAudio = narration.silent;
+    checkpoint.narrationProvider = narration.provider;
+    checkpoint.generatedAt = new Date().toISOString();
+    await writeJson(manifestPath, manifest);
+    return { checkpoint, files };
+  } catch (error) {
+    checkpoint.status = 'failed';
+    checkpoint.error = error.message;
+    await writeJson(manifestPath, manifest);
+    throw error;
+  }
+}
+
+async function attachThumbnail(youtube, videoId, thumbnailPath) {
+  await youtube.thumbnails.set({
+    videoId,
+    media: { body: fsSync.createReadStream(thumbnailPath) }
+  });
+}
+
+async function attachCaptions(youtube, videoId, captionsPath) {
+  await youtube.captions.insert({
+    part: 'snippet',
+    requestBody: {
+      snippet: {
+        videoId,
+        language: 'en',
+        name: 'English burned-caption transcript',
+        isDraft: false
+      }
+    },
+    media: { body: fsSync.createReadStream(captionsPath) }
+  });
+}
+
+async function uploadItem(youtube, topic, checkpoint, files, options, manifest, manifestPath) {
+  if (!checkpoint.youtube?.id) {
+    const publicShort = options.publicUpload === true;
+    const reservation = publicShort ? await reservePublicShort(`short-batch:${topic.key}`) : null;
+    let inserted = false;
+    try {
+      const response = await youtube.videos.insert({
+        part: 'snippet,status',
+        requestBody: {
+          snippet: {
+            title: topic.title.slice(0, 100),
+            description: buildYouTubeDescription(topic).slice(0, 5000),
+            tags: sanitizeTags(topic.tags),
+            categoryId: CATEGORY_ID,
+            defaultLanguage: 'en',
+            defaultAudioLanguage: 'en'
+          },
+          status: {
+            privacyStatus: publicShort ? 'public' : 'private',
+            selfDeclaredMadeForKids: false
+          }
+        },
+        media: { body: fsSync.createReadStream(files.video) }
+      });
+      const id = response.data.id;
+      if (!id) throw new Error(`YouTube did not return an ID for ${topic.key}`);
+      inserted = true;
+      if (reservation) await markPublicShortUploaded(reservation.key);
+      checkpoint.youtube = {
+        id,
+        url: `https://www.youtube.com/watch?v=${id}`,
+        privacyStatus: publicShort ? 'public' : 'private',
+        uploadedAt: new Date().toISOString(),
+        thumbnailAttached: false,
+        captionsAttached: false
+      };
+      checkpoint.status = 'uploaded';
+      await writeJson(manifestPath, manifest);
+      console.log(`Uploaded ${topic.key}: ${id}`);
+    } catch (error) {
+      if (reservation && !inserted) await releasePublicShort(reservation.key).catch(() => {});
+      throw error;
+    }
+  } else {
+    console.log(`Reusing YouTube checkpoint for ${topic.key}: ${checkpoint.youtube.id}`);
+  }
+
+  if (!options.skipThumbnails && !checkpoint.youtube.thumbnailAttached) {
+    await attachThumbnail(youtube, checkpoint.youtube.id, files.thumbnail);
+    checkpoint.youtube.thumbnailAttached = true;
+    await writeJson(manifestPath, manifest);
+  } else if (options.skipThumbnails && !checkpoint.youtube.thumbnailAttached) {
+    checkpoint.youtube.thumbnailPending = true;
+    await writeJson(manifestPath, manifest);
+  }
+
+  if (options.uploadCaptions && !checkpoint.youtube.captionsAttached) {
+    try {
+      await attachCaptions(youtube, checkpoint.youtube.id, files.srt);
+      checkpoint.youtube.captionsAttached = true;
+      await writeJson(manifestPath, manifest);
+    } catch (error) {
+      if (!/insufficient authentication scopes/i.test(error.message || '')) throw error;
+      console.warn(`Captions attachment skipped for ${topic.key}: OAuth token lacks the captions scope`);
+    }
+  }
+}
+
+async function runBatch(options) {
+  validateOptions(options);
+  const resolvedOutputDir = resolveFromRoot(options.outputDir);
+  if (resolvedOutputDir.toLowerCase() === LEGACY_BATCH_DIR.toLowerCase()) {
+    throw new Error('The legacy data/short-batch directory is preserved; use the default data/short-batch-cartoon output directory');
+  }
+  options.outputDir = resolvedOutputDir;
+  options.flowImageDir = resolveFromRoot(options.flowImageDir);
+  await fs.mkdir(options.outputDir, { recursive: true });
+  const manifestPath = path.join(options.outputDir, 'manifest.json');
+  const manifest = await readManifest(manifestPath);
+  manifest.version = 2;
+  manifest.renderVersion = RENDER_VERSION;
+  manifest.visualStyle = VISUAL_STYLE;
+  manifest.visualBeats = VISUAL_BEATS_COUNT;
+  manifest.status = options.upload ? (options.publicUpload ? 'public_uploading' : 'private_uploading') : 'preview';
+  manifest.count = options.count;
+  manifest.publicUpload = options.publicUpload;
+  manifest.generatedAt = manifest.generatedAt || new Date().toISOString();
+  await writeJson(manifestPath, manifest);
+
+  let sourceImages = [];
+  try {
+    sourceImages = await listFlowImages(options.flowImageDir);
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error;
+  }
+  if (sourceImages.length === 0) {
+    console.log('No Flow stills found; using local cartoon panels for visuals and thumbnails.');
+  }
+
+  const credentialManager = new CredentialManager();
+  const initialized = await credentialManager.initialize();
+  if (options.upload && !initialized) throw new Error('Could not load YouTube credentials for batch upload');
+  const generator = new AIVideoGenerator(credentialManager.credentials);
+  let youtube = null;
+  let channel = null;
+  if (options.upload) {
+    youtube = credentialManager.getYouTubeClient();
+    const channelResponse = await youtube.channels.list({ part: 'snippet', mine: true });
+    channel = channelResponse.data.items?.[0];
+    if (!channel) throw new Error('No authenticated YouTube channel was found');
+    if (channel.snippet.title !== EXPECTED_CHANNEL) {
+      throw new Error(`Authenticated channel is "${channel.snippet.title}", expected "${EXPECTED_CHANNEL}"`);
+    }
+    manifest.channel = { id: channel.id, title: channel.snippet.title };
+  }
+
+  const topics = FINANCE_TOPICS.slice(0, options.count);
+  for (let index = 0; index < topics.length; index += 1) {
+    const topic = topics[index];
+    const result = await generateItem(topic, sourceImages, generator, options, manifest, manifestPath);
+    if (youtube) {
+      await uploadItem(youtube, topic, result.checkpoint, result.files, options, manifest, manifestPath);
+      if (index < topics.length - 1 && DEFAULT_UPLOAD_DELAY_MS > 0) {
+        await new Promise(resolve => setTimeout(resolve, DEFAULT_UPLOAD_DELAY_MS));
+      }
+    }
+  }
+
+  manifest.status = options.upload ? 'uploaded' : 'preview_ready';
+  manifest.completedCount = topics.filter(topic => manifest.items[topic.key]?.status === 'uploaded' || manifest.items[topic.key]?.status === 'generated').length;
+  manifest.finishedAt = new Date().toISOString();
+  await writeJson(manifestPath, manifest);
+  return { manifestPath, count: topics.length, uploaded: Boolean(youtube), publicUpload: options.publicUpload };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+  const result = await runBatch(options);
+  console.log(JSON.stringify(result, null, 2));
+  if (!options.upload) console.log('Preview complete. Upload skipped; review the MP4, SRT, and manifest before using --upload.');
+}
+
+if (require.main === module) {
+  main().catch(error => {
+    console.error(`Short batch failed: ${error.stack || error.message}`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  DISCLAIMER,
+  FINANCE_TOPICS,
+  MAX_COUNT,
+  RENDER_VERSION,
+  VISUAL_BEATS_COUNT,
+  VISUAL_PLANS,
+  VISUAL_STYLE,
+  buildVisualScenes,
+  getVisualPlan,
+  parseArgs,
+  runBatch,
+  validateOptions
+};

--- a/shorts.js
+++ b/shorts.js
@@ -1,0 +1,420 @@
+require('dotenv').config();
+
+const axios = require('axios');
+const fs = require('fs');
+const fsp = fs.promises;
+const path = require('path');
+const { GoogleGenAI } = require('@google/genai');
+const { CredentialManager } = require('./utils/credential-manager');
+const {
+  markPublicShortUploaded,
+  reservePublicShort,
+  releasePublicShort
+} = require('./utils/youtube-rate-limit');
+
+const DEFAULT_MODEL = process.env.GEMINI_VIDEO_MODEL || 'gemini-omni-flash-preview';
+const DEFAULT_DURATION = Number(process.env.SHORT_DEFAULT_DURATION || 10);
+const DEFAULT_ASPECT_RATIO = process.env.SHORT_ASPECT_RATIO || '9:16';
+const DEFAULT_PRIVACY = process.env.SHORT_PRIVACY_STATUS || 'private';
+const VALID_DURATIONS = new Set([4, 6, 8, 10]);
+const VALID_ASPECT_RATIOS = new Set(['9:16', '16:9']);
+const VALID_PRIVACY_STATUSES = new Set(['private', 'unlisted', 'public']);
+
+function parseArgs(argv) {
+  const options = {
+    prompt: null,
+    model: DEFAULT_MODEL,
+    duration: DEFAULT_DURATION,
+    aspectRatio: DEFAULT_ASPECT_RATIO,
+    output: null,
+    upload: false,
+    privacy: DEFAULT_PRIVACY,
+    title: null,
+    description: null,
+    tags: [],
+    category: process.env.YOUTUBE_CATEGORY_ID || '24',
+    help: false
+  };
+  const positional = [];
+  const valueFlags = new Set([
+    '--prompt',
+    '--model',
+    '--duration',
+    '--aspect-ratio',
+    '--output',
+    '--privacy',
+    '--title',
+    '--description',
+    '--tags',
+    '--category'
+  ]);
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    const equalsIndex = argument.indexOf('=');
+    const flag = equalsIndex === -1 ? argument : argument.slice(0, equalsIndex);
+    let value = equalsIndex === -1 ? null : argument.slice(equalsIndex + 1);
+
+    if (flag === '--help' || flag === '-h') {
+      options.help = true;
+      continue;
+    }
+
+    if (flag === '--upload') {
+      options.upload = true;
+      continue;
+    }
+
+    if (!valueFlags.has(flag)) {
+      if (argument.startsWith('-')) {
+        throw new Error(`Unknown option: ${argument}`);
+      }
+      positional.push(argument);
+      continue;
+    }
+
+    if (value === null) {
+      value = argv[index + 1];
+      index += 1;
+    }
+
+    if (!value || value.startsWith('--')) {
+      throw new Error(`A value is required for ${flag}`);
+    }
+
+    switch (flag) {
+      case '--prompt':
+        options.prompt = value;
+        break;
+      case '--model':
+        options.model = value;
+        break;
+      case '--duration':
+        options.duration = Number(value);
+        break;
+      case '--aspect-ratio':
+        options.aspectRatio = value;
+        break;
+      case '--output':
+        options.output = value;
+        break;
+      case '--privacy':
+        options.privacy = value;
+        break;
+      case '--title':
+        options.title = value;
+        break;
+      case '--description':
+        options.description = value;
+        break;
+      case '--tags':
+        options.tags = value.split(',');
+        break;
+      case '--category':
+        options.category = value;
+        break;
+      default:
+        throw new Error(`Unhandled option: ${flag}`);
+    }
+  }
+
+  if (!options.prompt && positional.length > 0) {
+    options.prompt = positional.join(' ');
+  }
+
+  return options;
+}
+
+function validateOptions(options) {
+  if (!options.prompt || options.prompt.trim().length === 0) {
+    throw new Error('Provide a prompt as text or with --prompt "..."');
+  }
+
+  if (options.prompt.length > 10000) {
+    throw new Error('Prompt must be 10,000 characters or less');
+  }
+
+  if (!VALID_DURATIONS.has(options.duration)) {
+    throw new Error('Duration must be one of: 4, 6, 8, or 10 seconds');
+  }
+
+  if (!VALID_ASPECT_RATIOS.has(options.aspectRatio)) {
+    throw new Error('Aspect ratio must be 9:16 or 16:9');
+  }
+
+  if (!VALID_PRIVACY_STATUSES.has(options.privacy)) {
+    throw new Error('Privacy must be private, unlisted, or public');
+  }
+
+  if (!options.model || options.model.trim().length === 0) {
+    throw new Error('A Gemini video model is required');
+  }
+
+  if (!options.upload && options.privacy !== 'private') {
+    throw new Error('--privacy other than private requires --upload');
+  }
+
+  if (options.title && options.title.length > 100) {
+    throw new Error('YouTube titles must be 100 characters or less');
+  }
+
+  if (options.description && options.description.length > 5000) {
+    throw new Error('YouTube descriptions must be 5,000 characters or less');
+  }
+}
+
+function buildShortPrompt(options) {
+  const orientation = options.aspectRatio === '9:16' ? 'vertical' : 'landscape';
+
+  return [
+    `Create exactly a ${options.duration}-second ${orientation} video in ${options.aspectRatio} format for a YouTube Short.`,
+    options.prompt.trim(),
+    'Follow the requested subject, action, camera movement, lighting, and visual style. Do not add on-screen text unless requested.'
+  ].join('\n\n');
+}
+
+function createDefaultTitle(prompt) {
+  const compact = prompt.replace(/\s+/g, ' ').trim();
+  const title = compact.length > 86 ? `${compact.slice(0, 83).trim()}...` : compact;
+  return `AI Short: ${title}`.slice(0, 100);
+}
+
+function sanitizeTags(tags = []) {
+  const cleaned = tags
+    .map(tag => String(tag).trim())
+    .filter(Boolean);
+  const defaults = cleaned.length > 0 ? cleaned : ['Shorts', 'AI video', 'Gemini Omni Flash'];
+  const kept = [];
+  let total = 0;
+
+  for (const tag of defaults) {
+    if (total + tag.length + 1 > 500) {
+      break;
+    }
+    kept.push(tag);
+    total += tag.length + 1;
+  }
+
+  return kept;
+}
+
+function isExplicitShort(metadata = {}) {
+  return metadata.isShort === true
+    || String(metadata.contentType || '').toLowerCase() === 'short'
+    || metadata.aspectRatio === '9:16';
+}
+
+function shortReservationKey(options, videoPath) {
+  return options.reservationKey || `shorts:${path.resolve(videoPath)}`;
+}
+
+function extractVideoPart(response) {
+  const parts = (response.candidates || [])
+    .flatMap(candidate => candidate.content?.parts || []);
+
+  for (const part of parts) {
+    const inlineData = part.inlineData || part.inline_data;
+    const inlineMimeType = inlineData?.mimeType || inlineData?.mime_type || '';
+    if (inlineData?.data && (!inlineMimeType || /^video\//i.test(inlineMimeType))) {
+      return {
+        type: 'base64',
+        data: inlineData.data,
+        mimeType: inlineMimeType || 'video/mp4'
+      };
+    }
+
+    const fileData = part.fileData || part.file_data;
+    const fileUri = fileData?.fileUri || fileData?.file_uri;
+    if (fileUri) {
+      return {
+        type: 'uri',
+        uri: fileUri,
+        mimeType: fileData.mimeType || fileData.mime_type || 'video/mp4'
+      };
+    }
+  }
+
+  return null;
+}
+
+async function downloadVideoPart(ai, videoPart, outputPath, apiKey) {
+  await fsp.mkdir(path.dirname(outputPath), { recursive: true });
+
+  if (videoPart.type === 'base64') {
+    await fsp.writeFile(outputPath, Buffer.from(videoPart.data, 'base64'));
+  } else if (videoPart.uri.startsWith('files/') || videoPart.uri.includes('/files/')) {
+    await ai.files.download({ file: videoPart.uri, downloadPath: outputPath });
+  } else if (/^https?:\/\//i.test(videoPart.uri)) {
+    const response = await axios.get(videoPart.uri, {
+      responseType: 'arraybuffer',
+      headers: apiKey ? { 'x-goog-api-key': apiKey } : undefined
+    });
+    await fsp.writeFile(outputPath, response.data);
+  } else {
+    throw new Error(`Gemini returned an unsupported video URI: ${videoPart.uri}`);
+  }
+
+  const stats = await fsp.stat(outputPath);
+  if (!stats.isFile() || stats.size === 0) {
+    throw new Error('Gemini returned an empty video file');
+  }
+
+  return outputPath;
+}
+
+function getGeminiApiKey(credentials = {}) {
+  return process.env.GEMINI_API_KEY || credentials.gemini?.apiKey || null;
+}
+
+async function generateShort(options, credentials = {}) {
+  const apiKey = getGeminiApiKey(credentials);
+  if (!apiKey) {
+    throw new Error('GEMINI_API_KEY is not configured');
+  }
+
+  const outputPath = path.resolve(
+    __dirname,
+    options.output || path.join('data', 'videos', `omni_short_${Date.now()}.mp4`)
+  );
+  const ai = new GoogleGenAI({ apiKey });
+  const prompt = buildShortPrompt(options);
+
+  console.log(`Generating with ${options.model}...`);
+  const response = await ai.models.generateContent({
+    model: options.model,
+    contents: prompt,
+    config: {
+      responseModalities: ['VIDEO']
+    }
+  });
+  const videoPart = extractVideoPart(response);
+
+  if (!videoPart) {
+    const reason = response.promptFeedback?.blockReason || 'no video part returned';
+    const responseText = response.text ? ` ${response.text.slice(0, 300)}` : '';
+    throw new Error(`Gemini Omni Flash did not return a video (${reason}).${responseText}`);
+  }
+
+  await downloadVideoPart(ai, videoPart, outputPath, apiKey);
+  return { outputPath, prompt };
+}
+
+async function uploadToYouTube(options, videoPath) {
+  const credentialManager = new CredentialManager();
+  const initialized = await credentialManager.initialize();
+  if (!initialized) {
+    throw new Error('Could not load YouTube credentials');
+  }
+
+  let youtube;
+  try {
+    youtube = credentialManager.getYouTubeClient();
+  } catch (error) {
+    throw new Error(`YouTube is not authenticated. Run "node modern-auth.js" first. ${error.message}`);
+  }
+
+  const title = options.title || createDefaultTitle(options.prompt);
+  const description = options.description || 'Created with Gemini Omni Flash.\n\n#Shorts';
+  const publicShort = options.privacy === 'public' && isExplicitShort(options);
+  const reservation = publicShort
+    ? await reservePublicShort(shortReservationKey(options, videoPath))
+    : null;
+  let inserted = false;
+
+  try {
+    const response = await youtube.videos.insert({
+      part: 'snippet,status',
+      requestBody: {
+        snippet: {
+          title,
+          description,
+          tags: sanitizeTags(options.tags),
+          categoryId: String(options.category)
+        },
+        status: {
+          privacyStatus: options.privacy,
+          selfDeclaredMadeForKids: false
+        }
+      },
+      media: {
+        body: fs.createReadStream(videoPath)
+      }
+    });
+
+    const videoId = response.data.id;
+    if (!videoId) throw new Error('YouTube did not return an uploaded video ID');
+    inserted = true;
+    if (reservation) await markPublicShortUploaded(reservation.key);
+    return {
+      id: videoId,
+      url: `https://www.youtube.com/watch?v=${videoId}`,
+      privacyStatus: options.privacy,
+      title
+    };
+  } catch (error) {
+    if (reservation && !inserted) await releasePublicShort(reservation.key).catch(() => {});
+    throw error;
+  }
+}
+
+function printHelp() {
+  console.log(`Usage:
+  npm run short -- "your video prompt" [options]
+
+Options:
+  --upload                 Upload the generated MP4 to YouTube
+  --privacy <value>        private (default), unlisted, or public
+  --title <text>           YouTube title
+  --description <text>     YouTube description
+  --tags <a,b,c>           Comma-separated YouTube tags
+  --category <id>          YouTube category ID (default: 24)
+  --duration <seconds>     4, 6, 8, or 10 (default: 10)
+  --aspect-ratio <ratio>   9:16 (default) or 16:9
+  --model <model>          Gemini model (default: gemini-omni-flash-preview)
+  --output <path>          Output MP4 path
+  --help                   Show this help
+
+Examples:
+  npm run short -- "A golden retriever surfing at sunset"
+  npm run short -- "A golden retriever surfing at sunset" --upload --privacy private
+`);
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  validateOptions(options);
+  const credentialManager = new CredentialManager();
+  await credentialManager.initialize();
+  const generated = await generateShort(options, credentialManager.credentials);
+  console.log(`Video saved to: ${generated.outputPath}`);
+
+  if (options.upload) {
+    const upload = await uploadToYouTube(options, generated.outputPath);
+    console.log(`Uploaded to YouTube as ${upload.privacyStatus}: ${upload.url}`);
+  } else {
+    console.log('Upload skipped. Add --upload after reviewing the MP4.');
+  }
+}
+
+if (require.main === module) {
+  main().catch(error => {
+    console.error(`Short workflow failed: ${error.message}`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  buildShortPrompt,
+  createDefaultTitle,
+  extractVideoPart,
+  isExplicitShort,
+  parseArgs,
+  sanitizeTags,
+  uploadToYouTube,
+  validateOptions
+};

--- a/test.js
+++ b/test.js
@@ -45,7 +45,11 @@ class SystemTest {
       { name: 'Placeholder Scheduling Guard', test: () => this.testPlaceholderSchedulingGuard() },
       { name: 'FFmpeg Resolution', test: () => this.testFFmpegResolution() },
       { name: 'Gemini Media Provider Selection', test: () => this.testGeminiMediaProvider() },
+      { name: 'Gemini Omni Short Workflow', test: () => this.testGeminiOmniShortWorkflow() },
       { name: 'Slideshow Renderer', test: () => this.testSlideshowRenderer() },
+      { name: 'Short Renderer Caption Helpers', test: () => this.testShortRendererCaptionHelpers() },
+      { name: 'Cartoon Illustrations and Visual Plans', test: () => this.testCartoonIllustrationsAndVisualPlans() },
+      { name: 'Public Short Rate Limit Guard', test: () => this.testPublicShortRateLimitGuard() },
       { name: 'Evergreen Template Topics', test: () => this.testEvergreenTopics() },
       { name: 'Walkthrough Module', test: () => this.testWalkthroughModule() },
       { name: 'Logger System', test: () => this.testLogger() },
@@ -2181,7 +2185,7 @@ class SystemTest {
     const manager = new CredentialManager();
 
     // Isolate the test from any API keys set in the environment
-    const envKeys = [...Object.values(PROVIDERS).map(p => p.envKey), 'GEMINI_API_KEY'];
+    const envKeys = [...Object.values(PROVIDERS).map(p => p.envKey), 'GEMINI_API_KEY', 'ANTHROPIC_API_KEY'];
     const savedEnv = {};
     for (const key of envKeys) {
       savedEnv[key] = process.env[key];
@@ -2457,6 +2461,80 @@ class SystemTest {
     this.logger.info('Gemini media provider selection test completed successfully');
   }
 
+  async testGeminiOmniShortWorkflow() {
+    const {
+      buildShortPrompt,
+      createDefaultTitle,
+      extractVideoPart,
+      parseArgs,
+      sanitizeTags,
+      validateOptions
+    } = require('./shorts');
+
+    const options = parseArgs([
+      'A',
+      'robot',
+      'walking',
+      'through',
+      'rain',
+      '--upload',
+      '--privacy',
+      'private',
+      '--duration',
+      '8',
+      '--aspect-ratio',
+      '9:16'
+    ]);
+
+    validateOptions(options);
+    const prompt = buildShortPrompt(options);
+    if (!prompt.includes('8-second') || !prompt.includes('9:16') || !prompt.includes('robot')) {
+      throw new Error('Short prompt was not assembled correctly');
+    }
+
+    const videoPart = extractVideoPart({
+      candidates: [{
+        content: {
+          parts: [{ inlineData: { mimeType: 'video/mp4', data: 'ZmFrZQ==' } }]
+        }
+      }]
+    });
+    if (!videoPart || videoPart.type !== 'base64' || videoPart.data !== 'ZmFrZQ==') {
+      throw new Error('Inline video response was not extracted');
+    }
+
+    const uriPart = extractVideoPart({
+      candidates: [{
+        content: {
+          parts: [{ fileData: { fileUri: 'files/short-video', mimeType: 'video/mp4' } }]
+        }
+      }]
+    });
+    if (!uriPart || uriPart.type !== 'uri' || uriPart.uri !== 'files/short-video') {
+      throw new Error('URI video response was not extracted');
+    }
+
+    if (sanitizeTags([' first ', '', 'second']).join(',') !== 'first,second') {
+      throw new Error('YouTube tags were not sanitized');
+    }
+
+    if (!createDefaultTitle('A simple test prompt').startsWith('AI Short:')) {
+      throw new Error('Default YouTube title was not created');
+    }
+
+    let invalidPrivacyRejected = false;
+    try {
+      validateOptions({ ...options, upload: false, privacy: 'public' });
+    } catch (error) {
+      invalidPrivacyRejected = /requires --upload/.test(error.message);
+    }
+    if (!invalidPrivacyRejected) {
+      throw new Error('Public privacy without upload was not rejected');
+    }
+
+    this.logger.info('Gemini Omni short workflow test completed successfully');
+  }
+
   async testSlideshowRenderer() {
     const { AIVideoGenerator } = require('./utils/ai-video-generator');
     const { checkFFmpeg } = require('./utils/ffmpeg');
@@ -2550,6 +2628,159 @@ class SystemTest {
     }
 
     this.logger.info('Slideshow renderer test completed successfully');
+  }
+
+  async testShortRendererCaptionHelpers() {
+    const {
+      buildSubtitleFilter,
+      calculateCardDurations,
+      chunkWords,
+      createSrtCaptions,
+      escapeSubtitleFilterPath,
+      formatSrtTime
+    } = require('./utils/short-video-renderer');
+
+    const chunks = chunkWords('one two three four five six seven', 3);
+    if (chunks.length !== 3 || chunks.some(chunk => chunk.length > 3)) {
+      throw new Error('Short caption chunks did not respect the word limit');
+    }
+
+    const captions = createSrtCaptions('one two three four five six seven', 10, { maxWords: 3 });
+    if (!captions.includes('00:00:00,000') || !captions.includes('00:00:10,000')) {
+      throw new Error('SRT captions did not span the measured duration');
+    }
+    if (formatSrtTime(1.25) !== '00:00:01,250') {
+      throw new Error('SRT timestamp formatting was incorrect');
+    }
+
+    const timing = calculateCardDurations(12, Array.from({ length: 12 }, () => ({ title: 'beat' })));
+    const renderedDuration = timing.durations.reduce((sum, value) => sum + value, 0)
+      - (timing.fadeDuration * 11);
+    if (Math.abs(renderedDuration - 12) > 0.01) {
+      throw new Error('Card timing did not account for xfade overlap');
+    }
+
+    const escaped = escapeSubtitleFilterPath('C:\\Users\\Admin\\caption file.srt');
+    if (!escaped.includes('\\:') || escaped.includes('\\Users')) {
+      throw new Error('Windows subtitle path was not escaped safely');
+    }
+    const filter = buildSubtitleFilter('C:\\Users\\Admin\\caption file.srt');
+    if (!filter.includes('force_style=') || !filter.includes('subtitles=filename=')) {
+      throw new Error('ASS-style subtitle filter was not assembled');
+    }
+
+    this.logger.info('Short renderer caption helper test completed successfully');
+  }
+
+  async testCartoonIllustrationsAndVisualPlans() {
+    const {
+      FINANCE_TOPICS,
+      VISUAL_BEATS_COUNT,
+      VISUAL_PLANS,
+      buildVisualScenes
+    } = require('./short-batch');
+    const {
+      ILLUSTRATION_HEIGHT,
+      ILLUSTRATION_WIDTH,
+      SUPPORTED_KINDS,
+      buildIllustrationSvg,
+      createCartoonIllustrations,
+      isSupportedKind
+    } = require('./utils/cartoon-illustrations');
+    const fs = require('fs').promises;
+    const os = require('os');
+    const sharp = require('sharp');
+
+    if (FINANCE_TOPICS.length !== 20 || Object.keys(VISUAL_PLANS).length !== 20) {
+      throw new Error('The finance batch and cartoon plan do not cover all 20 topics');
+    }
+    if (!['cash', 'jar', 'calendar', 'shield', 'credit-card', 'scale', 'chart', 'house', 'receipt', 'warning', 'target', 'clock', 'people', 'tax', 'scam'].every(kind => SUPPORTED_KINDS.includes(kind) && isSupportedKind(kind))) {
+      throw new Error('The cartoon module is missing a required semantic kind');
+    }
+
+    for (const topic of FINANCE_TOPICS) {
+      const scenes = buildVisualScenes(topic);
+      if (scenes.length !== VISUAL_BEATS_COUNT || scenes.some(scene => !scene.kind || !isSupportedKind(scene.kind))) {
+        throw new Error(`Visual plan for ${topic.key} is incomplete or has an unsupported kind`);
+      }
+      if (new Set(scenes.map(scene => `${scene.title}:${scene.detail}`)).size !== VISUAL_BEATS_COUNT) {
+        throw new Error(`Visual plan for ${topic.key} repeats a scene description`);
+      }
+    }
+
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'yaa-cartoon-'));
+    try {
+      const scenes = buildVisualScenes(FINANCE_TOPICS[0]);
+      const panelPaths = await createCartoonIllustrations(scenes, dir, { topicKey: FINANCE_TOPICS[0].key });
+      if (panelPaths.length !== VISUAL_BEATS_COUNT || new Set(panelPaths).size !== VISUAL_BEATS_COUNT) {
+        throw new Error('Cartoon illustration generation did not create 12 unique panel files');
+      }
+      const metadata = await sharp(panelPaths[0]).metadata();
+      if (metadata.format !== 'png' || metadata.width !== ILLUSTRATION_WIDTH || metadata.height !== ILLUSTRATION_HEIGHT) {
+        throw new Error('Cartoon illustration was not rendered as a vertical PNG');
+      }
+      const svg = buildIllustrationSvg({ kind: 'scam', title: 'Verify first', detail: 'Pause before trusting a money offer' });
+      if (!svg.includes('<svg') || !svg.includes('SCAM PANEL')) {
+        throw new Error('Cartoon SVG helper did not render the requested semantic kind');
+      }
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    }
+
+    this.logger.info('Cartoon illustration and visual plan test completed successfully');
+  }
+
+  async testPublicShortRateLimitGuard() {
+    const {
+      countPublicShorts,
+      getPublicShortStatus,
+      markPublicShortUploaded,
+      reservePublicShort,
+      releasePublicShort
+    } = require('./utils/youtube-rate-limit');
+    const fs = require('fs').promises;
+    const os = require('os');
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'yaa-rate-limit-'));
+    const common = {
+      statePath: path.join(dir, 'state.json'),
+      lockPath: path.join(dir, 'lock'),
+      limit: 2,
+      timeZone: 'UTC',
+      now: new Date('2026-08-26T12:00:00.000Z')
+    };
+
+    try {
+      const first = await reservePublicShort('first', common);
+      const duplicate = await reservePublicShort('first', common);
+      if (first.count !== 1 || !duplicate.alreadyReserved || duplicate.count !== 1) {
+        throw new Error('Rate-limit reservation was not idempotent');
+      }
+
+      await reservePublicShort('second', common);
+      let limitRejected = false;
+      try {
+        await reservePublicShort('third', common);
+      } catch (error) {
+        limitRejected = error.code === 'YOUTUBE_PUBLIC_SHORTS_DAILY_LIMIT';
+      }
+      if (!limitRejected) throw new Error('Daily public Short cap did not reject the third reservation');
+
+      await releasePublicShort('second', common);
+      const third = await reservePublicShort('third', common);
+      await markPublicShortUploaded(third.key, common);
+      const releasedUploaded = await releasePublicShort(third.key, common);
+      const status = await getPublicShortStatus(common);
+      if (releasedUploaded.released || status.reservations !== 1 || status.uploads !== 1) {
+        throw new Error('Rate-limit release/upload lifecycle was incorrect');
+      }
+      if (await countPublicShorts(common) !== 2) {
+        throw new Error('Rate-limit count helper returned the wrong active count');
+      }
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    }
+
+    this.logger.info('Public Short rate-limit guard test completed successfully');
   }
 
   async testEvergreenTopics() {

--- a/utils/ai-text-service.js
+++ b/utils/ai-text-service.js
@@ -1,4 +1,5 @@
 const OpenAI = require('openai');
+const axios = require('axios');
 const { Logger } = require('./logger');
 
 const GEMINI_MODELS = [
@@ -51,6 +52,7 @@ class AITextService {
     this.logger = new Logger('AITextService');
     this.client = null;
     this.gemini = null;
+    this.anthropic = null;
     this.model = null;
     this.providerName = null;
 
@@ -64,6 +66,11 @@ class AITextService {
 
     if (provider && PROVIDERS[provider] && apiKey) {
       return this._initOpenAICompatible(PROVIDERS[provider], apiKey, model);
+    }
+
+    const anthropicKey = credentials.anthropic?.apiKey || process.env.ANTHROPIC_API_KEY;
+    if (anthropicKey) {
+      return this._initAnthropic(anthropicKey, credentials.anthropic?.model);
     }
 
     for (const [, preset] of Object.entries(PROVIDERS)) {
@@ -100,10 +107,42 @@ class AITextService {
     }
   }
 
+  _initAnthropic(apiKey, model) {
+    this.anthropic = { apiKey };
+    this.model = model || process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-5';
+    this.providerName = 'Anthropic Claude';
+    this.logger.info(`Anthropic Claude initialized (model: ${this.model})`);
+  }
+
   async generateText(prompt, options = {}) {
     const model = options.model || this.model;
     const maxTokens = options.maxTokens || 2048;
     const temperature = options.temperature ?? 0.7;
+
+    if (this.anthropic) {
+      const response = await axios.post(
+        'https://api.anthropic.com/v1/messages',
+        {
+          model,
+          max_tokens: maxTokens,
+          temperature,
+          messages: [{ role: 'user', content: prompt }],
+        },
+        {
+          headers: {
+            'content-type': 'application/json',
+            'x-api-key': this.anthropic.apiKey,
+            'anthropic-version': '2023-06-01',
+          },
+          timeout: 120000,
+        },
+      );
+
+      return (response.data.content || [])
+        .filter(part => part.type === 'text')
+        .map(part => part.text)
+        .join('\n');
+    }
 
     if (this.gemini) {
       const config = { maxOutputTokens: maxTokens };
@@ -178,7 +217,7 @@ class AITextService {
   }
 
   isAvailable() {
-    return !!(this.client || this.gemini);
+    return !!(this.client || this.gemini || this.anthropic);
   }
 }
 

--- a/utils/ai-video-generator.js
+++ b/utils/ai-video-generator.js
@@ -64,18 +64,20 @@ class AIVideoGenerator {
     this.lastNarrationResult = null;
     let provider = 'simulation';
     let model = null;
+    const preferredProvider = String(process.env.TTS_PROVIDER || 'auto').toLowerCase();
+    const allows = candidate => preferredProvider === 'auto' || preferredProvider === candidate;
 
     try {
       let generatedPath;
-      if (this.elevenLabsApiKey && this.elevenLabsVoiceId) {
+      if (allows('elevenlabs') && this.elevenLabsApiKey && this.elevenLabsVoiceId) {
         provider = 'elevenlabs';
         model = this.elevenLabsModel;
         generatedPath = await this.generateElevenLabsTTS(text, outputPath);
-      } else if (this.openai) {
+      } else if (allows('openai') && this.openai) {
         provider = 'openai';
         model = 'gpt-4o-mini-tts';
         generatedPath = await this.generateOpenAITTS(text, outputPath);
-      } else if (this.gemini) {
+      } else if (allows('gemini') && this.gemini) {
         provider = 'gemini';
         model = process.env.GEMINI_TTS_MODEL || 'gemini-3.1-flash-tts-preview';
         generatedPath = await this.generateGeminiTTS(text, outputPath);

--- a/utils/cartoon-illustrations.js
+++ b/utils/cartoon-illustrations.js
@@ -1,0 +1,494 @@
+const fs = require('fs').promises;
+const path = require('path');
+const sharp = require('sharp');
+
+const ILLUSTRATION_WIDTH = 720;
+const ILLUSTRATION_HEIGHT = 1280;
+
+const PALETTES = Object.freeze([
+  Object.freeze({ background: '#10233f', panel: '#173d63', ink: '#f7fbff', muted: '#b7c9dc', primary: '#f6c75d', secondary: '#7dd3fc', good: '#68d391', danger: '#fb7185' }),
+  Object.freeze({ background: '#2b1738', panel: '#4b265d', ink: '#fff8fb', muted: '#dfbed8', primary: '#f59e9e', secondary: '#c4b5fd', good: '#86efac', danger: '#fb7185' }),
+  Object.freeze({ background: '#12362f', panel: '#1d5a4d', ink: '#f4fffb', muted: '#b8d9d0', primary: '#facc15', secondary: '#67e8f9', good: '#86efac', danger: '#fda4af' }),
+  Object.freeze({ background: '#382617', panel: '#62401f', ink: '#fffaf0', muted: '#e5cda9', primary: '#fb923c', secondary: '#fde68a', good: '#a7f3d0', danger: '#fca5a5' }),
+  Object.freeze({ background: '#202844', panel: '#303c68', ink: '#f6f8ff', muted: '#c2cbe4', primary: '#a7f3d0', secondary: '#93c5fd', good: '#bef264', danger: '#fda4af' }),
+  Object.freeze({ background: '#321c2c', panel: '#5b2e47', ink: '#fff7fb', muted: '#e4bdcf', primary: '#f9a8d4', secondary: '#fde68a', good: '#86efac', danger: '#fb7185' })
+]);
+
+const SUPPORTED_KINDS = Object.freeze([
+  'cash',
+  'jar',
+  'calendar',
+  'shield',
+  'credit-card',
+  'scale',
+  'chart',
+  'house',
+  'receipt',
+  'warning',
+  'target',
+  'clock',
+  'people',
+  'tax',
+  'scam',
+  'lock',
+  'document',
+  'coins',
+  'bucket',
+  'ladder'
+]);
+
+const KIND_ALIASES = Object.freeze({
+  'creditcard': 'credit-card',
+  'credit-card': 'credit-card',
+  'piggy-bank': 'jar',
+  money: 'cash',
+  bill: 'receipt',
+  'calendar-check': 'calendar',
+  graph: 'chart',
+  home: 'house',
+  identity: 'people',
+  fraud: 'scam'
+});
+
+function escapeXml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function hashString(value) {
+  let hash = 2166136261;
+  for (const character of String(value)) {
+    hash ^= character.charCodeAt(0);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function normalizeKind(kind) {
+  const value = String(kind || '').trim().toLowerCase().replace(/[_\s]+/g, '-');
+  const normalized = KIND_ALIASES[value] || value;
+  if (!SUPPORTED_KINDS.includes(normalized)) {
+    throw new Error(`Unsupported cartoon illustration kind: ${kind}`);
+  }
+  return normalized;
+}
+
+function isSupportedKind(kind) {
+  try {
+    normalizeKind(kind);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getPalette(seed = '') {
+  return PALETTES[hashString(seed) % PALETTES.length];
+}
+
+function colorsFor(theme = {}) {
+  return {
+    background: escapeXml(theme.background || PALETTES[0].background),
+    panel: escapeXml(theme.panel || PALETTES[0].panel),
+    ink: escapeXml(theme.ink || PALETTES[0].ink),
+    muted: escapeXml(theme.muted || PALETTES[0].muted),
+    primary: escapeXml(theme.primary || PALETTES[0].primary),
+    secondary: escapeXml(theme.secondary || PALETTES[0].secondary),
+    good: escapeXml(theme.good || PALETTES[0].good),
+    danger: escapeXml(theme.danger || PALETTES[0].danger)
+  };
+}
+
+function wrapText(value, maxCharacters) {
+  const words = String(value || '').trim().split(/\s+/).filter(Boolean);
+  const lines = [];
+  let line = '';
+  for (const word of words) {
+    const candidate = line ? `${line} ${word}` : word;
+    if (line && candidate.length > maxCharacters) {
+      lines.push(line);
+      line = word;
+    } else {
+      line = candidate;
+    }
+  }
+  if (line) lines.push(line);
+  return lines;
+}
+
+function drawCash(c) {
+  return `
+    <g stroke="${c.ink}" stroke-width="10" stroke-linejoin="round">
+      <rect x="-220" y="-80" width="440" height="170" rx="24" fill="${c.primary}"/>
+      <rect x="-190" y="-50" width="380" height="110" rx="14" fill="${c.secondary}" opacity="0.35"/>
+      <circle cx="0" cy="5" r="43" fill="${c.panel}"/>
+      <text x="0" y="24" text-anchor="middle" fill="${c.ink}" stroke="none" font-family="Arial, sans-serif" font-size="54" font-weight="900">$</text>
+      <path d="M-190 24 H-118 M118 24 H190" fill="none"/>
+      <rect x="-140" y="130" width="280" height="78" rx="18" fill="${c.good}"/>
+      <path d="M-96 169 H96" fill="none"/>
+    </g>`;
+}
+
+function drawJar(c) {
+  return `
+    <g stroke="${c.ink}" stroke-width="10" stroke-linejoin="round">
+      <path d="M-150 -110 H150 L130 170 Q0 235 -130 170 Z" fill="${c.secondary}"/>
+      <rect x="-168" y="-145" width="336" height="58" rx="16" fill="${c.primary}"/>
+      <path d="M-94 -88 V-124 M0 -88 V-124 M94 -88 V-124" fill="none"/>
+      <circle cx="-72" cy="20" r="35" fill="${c.primary}"/>
+      <circle cx="20" cy="62" r="35" fill="${c.good}"/>
+      <circle cx="82" cy="-8" r="35" fill="${c.primary}"/>
+      <text x="-72" y="35" text-anchor="middle" fill="${c.panel}" stroke="none" font-family="Arial, sans-serif" font-size="35" font-weight="900">$</text>
+      <text x="20" y="77" text-anchor="middle" fill="${c.panel}" stroke="none" font-family="Arial, sans-serif" font-size="35" font-weight="900">$</text>
+    </g>`;
+}
+
+function drawCalendar(c) {
+  return `
+    <g stroke="${c.ink}" stroke-width="10" stroke-linejoin="round">
+      <rect x="-220" y="-170" width="440" height="390" rx="28" fill="${c.ink}"/>
+      <rect x="-208" y="-158" width="416" height="104" rx="18" fill="${c.primary}"/>
+      <rect x="-170" y="-207" width="38" height="86" rx="18" fill="${c.secondary}"/>
+      <rect x="132" y="-207" width="38" height="86" rx="18" fill="${c.secondary}"/>
+      <g fill="${c.panel}" stroke="none">
+        <rect x="-156" y="-5" width="52" height="52" rx="10"/>
+        <rect x="-26" y="-5" width="52" height="52" rx="10"/>
+        <rect x="104" y="-5" width="52" height="52" rx="10"/>
+        <rect x="-156" y="78" width="52" height="52" rx="10"/>
+        <rect x="-26" y="78" width="52" height="52" rx="10" fill="${c.good}"/>
+        <rect x="104" y="78" width="52" height="52" rx="10"/>
+        <rect x="-156" y="161" width="52" height="32" rx="10"/>
+        <rect x="-26" y="161" width="52" height="32" rx="10"/>
+        <rect x="104" y="161" width="52" height="32" rx="10"/>
+      </g>
+      <path d="M-5 85 L10 101 L42 66" fill="none" stroke="${c.panel}"/>
+    </g>`;
+}
+
+function drawShield(c) {
+  return `
+    <g stroke="${c.ink}" stroke-width="12" stroke-linejoin="round">
+      <path d="M0 -220 L180 -150 V-8 Q164 154 0 232 Q-164 154 -180 -8 V-150 Z" fill="${c.secondary}"/>
+      <path d="M-86 8 L-25 70 L92 -62" fill="none" stroke="${c.good}" stroke-width="28"/>
+      <path d="M0 -174 V-112" fill="none" stroke="${c.primary}" stroke-width="18"/>
+    </g>`;
+}
+
+function drawCreditCard(c) {
+  return `
+    <g stroke="${c.ink}" stroke-width="10" stroke-linejoin="round">
+      <rect x="-235" y="-145" width="470" height="290" rx="28" fill="${c.primary}"/>
+      <rect x="-235" y="-68" width="470" height="52" fill="${c.panel}"/>
+      <rect x="-176" y="18" width="70" height="58" rx="10" fill="${c.secondary}"/>
+      <path d="M-72 39 H148 M-72 78 H76" fill="none"/>
+      <path d="M-178 112 H-38 M-12 112 H70" fill="none" stroke="${c.panel}"/>
+    </g>`;
+}
+
+function drawScale(c) {
+  return `
+    <g stroke="${c.ink}" stroke-width="11" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M0 -175 V170 M-125 190 H125" fill="none"/>
+      <path d="M-205 -112 H205" fill="none" stroke="${c.primary}" stroke-width="18"/>
+      <path d="M-150 -104 L-208 32 H-92 Z M150 -104 L92 32 H208 Z" fill="${c.secondary}"/>
+      <path d="M-205 32 Q-150 75 -92 32 M92 32 Q150 75 208 32" fill="none"/>
+      <circle cx="0" cy="-175" r="25" fill="${c.good}"/>
+    </g>`;
+}
+
+function drawChart(c) {
+  return `
+    <g stroke="${c.ink}" stroke-width="10" stroke-linejoin="round" stroke-linecap="round">
+      <path d="M-220 185 V-180 M-220 185 H230" fill="none"/>
+      <rect x="-170" y="56" width="62" height="129" rx="12" fill="${c.secondary}"/>
+      <rect x="-72" y="-24" width="62" height="209" rx="12" fill="${c.primary}"/>
+      <rect x="26" y="-96" width="62" height="281" rx="12" fill="${c.good}"/>
+      <path d="M-174 26 L-42 -38 L54 -116 L178 -174" fill="none" stroke="${c.danger}" stroke-width="18"/>
+      <circle cx="-174" cy="26" r="15" fill="${c.danger}"/>
+      <circle cx="-42" cy="-38" r="15" fill="${c.danger}"/>
+      <circle cx="54" cy="-116" r="15" fill="${c.danger}"/>
+      <circle cx="178" cy="-174" r="15" fill="${c.danger}"/>
+    </g>`;
+}
+
+function drawHouse(c) {
+  return `
+    <g stroke="${c.ink}" stroke-width="11" stroke-linejoin="round">
+      <path d="M-246 -25 L0 -225 L246 -25" fill="${c.primary}"/>
+      <path d="M-190 -30 H190 V190 H-190 Z" fill="${c.secondary}"/>
+      <rect x="-45" y="62" width="90" height="128" rx="12" fill="${c.panel}"/>
+      <rect x="-140" y="18" width="68" height="68" rx="10" fill="${c.good}"/>
+      <rect x="72" y="18" width="68" height="68" rx="10" fill="${c.good}"/>
+      <path d="M-106 18 V86 M-140 52 H-72 M106 18 V86 M72 52 H140" fill="none" stroke="${c.panel}"/>
+      <path d="M-235 190 H235" fill="none"/>
+    </g>`;
+}
+
+function drawReceipt(c) {
+  return `
+    <g stroke="${c.ink}" stroke-width="10" stroke-linejoin="round">
+      <path d="M-170 -205 H170 V174 L116 140 L62 174 L0 140 L-62 174 L-116 140 L-170 174 Z" fill="${c.ink}"/>
+      <path d="M-106 -120 H106 M-106 -56 H80 M-106 8 H106 M-106 72 H40" fill="none" stroke="${c.panel}" stroke-linecap="round"/>
+      <rect x="76" y="-73" width="46" height="46" rx="8" fill="${c.primary}"/>
+      <path d="M87 -50 L101 -36 L118 -61" fill="none" stroke="${c.panel}"/>
+    </g>`;
+}
+
+function drawWarning(c) {
+  return `
+    <g stroke="${c.ink}" stroke-width="12" stroke-linejoin="round">
+      <path d="M0 -230 L238 190 H-238 Z" fill="${c.danger}"/>
+      <path d="M0 -112 V42" fill="none" stroke="${c.panel}" stroke-width="30" stroke-linecap="round"/>
+      <circle cx="0" cy="103" r="18" fill="${c.panel}" stroke="none"/>
+      <path d="M-154 190 H154" fill="none" stroke="${c.primary}" stroke-width="20"/>
+    </g>`;
+}
+
+function drawTarget(c) {
+  return `
+    <g stroke="${c.ink}" stroke-width="11">
+      <circle cx="0" cy="0" r="210" fill="${c.secondary}"/>
+      <circle cx="0" cy="0" r="140" fill="${c.panel}"/>
+      <circle cx="0" cy="0" r="70" fill="${c.danger}"/>
+      <path d="M-250 190 L-82 22" fill="none" stroke="${c.primary}" stroke-width="24" stroke-linecap="round"/>
+      <path d="M-98 24 L-72 -20 L-42 9 Z" fill="${c.primary}"/>
+    </g>`;
+}
+
+function drawClock(c) {
+  return `
+    <g stroke="${c.ink}" stroke-width="12" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="0" cy="0" r="205" fill="${c.secondary}"/>
+      <circle cx="0" cy="0" r="170" fill="${c.panel}"/>
+      <path d="M0 -132 V0 L92 68" fill="none" stroke="${c.primary}" stroke-width="24"/>
+      <circle cx="0" cy="0" r="22" fill="${c.good}"/>
+      <path d="M0 -205 V-178 M205 0 H178 M0 205 V178 M-205 0 H-178" fill="none"/>
+    </g>`;
+}
+
+function drawPeople(c) {
+  return `
+    <g stroke="${c.ink}" stroke-width="10" stroke-linejoin="round">
+      <circle cx="-132" cy="-104" r="58" fill="${c.primary}"/>
+      <circle cx="132" cy="-104" r="58" fill="${c.secondary}"/>
+      <circle cx="0" cy="-154" r="68" fill="${c.good}"/>
+      <path d="M-230 190 Q-220 24 -132 24 Q-44 24 -34 190 Z" fill="${c.secondary}"/>
+      <path d="M34 190 Q44 24 132 24 Q220 24 230 190 Z" fill="${c.primary}"/>
+      <path d="M-105 190 Q-92 -6 0 -6 Q92 -6 105 190 Z" fill="${c.good}"/>
+    </g>`;
+}
+
+function drawTax(c) {
+  return `
+    <g stroke="${c.ink}" stroke-width="10" stroke-linejoin="round">
+      <path d="M-170 -210 H78 L170 -118 V210 H-170 Z" fill="${c.ink}"/>
+      <path d="M78 -210 V-118 H170" fill="${c.secondary}"/>
+      <path d="M-110 -42 H104 M-110 36 H60" fill="none" stroke="${c.panel}" stroke-linecap="round"/>
+      <text x="0" y="145" text-anchor="middle" fill="${c.primary}" stroke="none" font-family="Arial, sans-serif" font-size="112" font-weight="900">%</text>
+    </g>`;
+}
+
+function drawScam(c) {
+  return `
+    <g stroke="${c.ink}" stroke-width="10" stroke-linejoin="round">
+      <rect x="-150" y="-220" width="300" height="440" rx="42" fill="${c.panel}"/>
+      <rect x="-106" y="-142" width="212" height="210" rx="20" fill="${c.secondary}"/>
+      <path d="M-72 -66 H72 M-72 -14 H38" fill="none" stroke="${c.panel}" stroke-linecap="round"/>
+      <path d="M-50 28 L0 -24 L50 28" fill="none" stroke="${c.danger}" stroke-width="18"/>
+      <circle cx="0" cy="145" r="18" fill="${c.primary}" stroke="none"/>
+      <path d="M-84 112 H84" fill="none" stroke="${c.muted}"/>
+      <path d="M-230 168 L-185 92 L-140 168 Z" fill="${c.danger}"/>
+      <path d="M-185 121 V145" fill="none" stroke="${c.panel}" stroke-width="12"/>
+      <circle cx="-185" cy="157" r="7" fill="${c.panel}" stroke="none"/>
+    </g>`;
+}
+
+function drawLock(c) {
+  return `
+    <g stroke="${c.ink}" stroke-width="12" stroke-linejoin="round">
+      <rect x="-170" y="-10" width="340" height="250" rx="28" fill="${c.primary}"/>
+      <path d="M-105 -10 V-95 Q-105 -205 0 -205 Q105 -205 105 -95 V-10" fill="none"/>
+      <circle cx="0" cy="95" r="28" fill="${c.panel}" stroke="none"/>
+      <path d="M0 123 V174" fill="none" stroke="${c.panel}"/>
+      <path d="M-224 248 H224" fill="none" stroke="${c.secondary}" stroke-width="20"/>
+    </g>`;
+}
+
+function drawDocument(c) {
+  return `
+    <g stroke="${c.ink}" stroke-width="10" stroke-linejoin="round">
+      <path d="M-176 -220 H72 L176 -116 V220 H-176 Z" fill="${c.ink}"/>
+      <path d="M72 -220 V-116 H176" fill="${c.secondary}"/>
+      <path d="M-112 -72 H108 M-112 0 H108 M-112 72 H56" fill="none" stroke="${c.panel}" stroke-linecap="round"/>
+      <rect x="-112" y="120" width="58" height="48" rx="8" fill="${c.primary}"/>
+      <path d="M-98 144 L-82 158 L-58 130" fill="none" stroke="${c.panel}"/>
+    </g>`;
+}
+
+function drawCoins(c) {
+  return `
+    <g stroke="${c.ink}" stroke-width="10" stroke-linejoin="round">
+      <path d="M-154 -124 V124 Q-154 176 0 176 Q154 176 154 124 V-124" fill="${c.primary}"/>
+      <ellipse cx="0" cy="-124" rx="154" ry="52" fill="${c.secondary}"/>
+      <ellipse cx="0" cy="-18" rx="154" ry="52" fill="${c.good}"/>
+      <path d="M-154 -18 Q0 34 154 -18" fill="none"/>
+      <text x="0" y="-104" text-anchor="middle" fill="${c.panel}" stroke="none" font-family="Arial, sans-serif" font-size="48" font-weight="900">$</text>
+    </g>`;
+}
+
+function drawBucket(c) {
+  return `
+    <g stroke="${c.ink}" stroke-width="11" stroke-linejoin="round">
+      <path d="M-170 -85 H170 L126 200 H-126 Z" fill="${c.secondary}"/>
+      <path d="M-150 -85 Q-150 -230 0 -230 Q150 -230 150 -85" fill="none"/>
+      <path d="M-118 -12 H118 M-98 68 H98" fill="none" stroke="${c.panel}" stroke-linecap="round"/>
+      <circle cx="0" cy="135" r="35" fill="${c.primary}"/>
+      <text x="0" y="151" text-anchor="middle" fill="${c.panel}" stroke="none" font-family="Arial, sans-serif" font-size="34" font-weight="900">$</text>
+    </g>`;
+}
+
+function drawLadder(c) {
+  return `
+    <g stroke="${c.ink}" stroke-width="14" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M-150 -205 L-80 205 M150 -205 L80 205" fill="none" stroke="${c.secondary}" stroke-width="28"/>
+      <path d="M-132 -130 H132 M-116 -42 H116 M-100 46 H100 M-84 134 H84" fill="none" stroke="${c.primary}" stroke-width="20"/>
+      <path d="M-222 205 H222" fill="none" stroke="${c.good}"/>
+    </g>`;
+}
+
+const KIND_RENDERERS = Object.freeze({
+  cash: drawCash,
+  jar: drawJar,
+  calendar: drawCalendar,
+  shield: drawShield,
+  'credit-card': drawCreditCard,
+  scale: drawScale,
+  chart: drawChart,
+  house: drawHouse,
+  receipt: drawReceipt,
+  warning: drawWarning,
+  target: drawTarget,
+  clock: drawClock,
+  people: drawPeople,
+  tax: drawTax,
+  scam: drawScam,
+  lock: drawLock,
+  document: drawDocument,
+  coins: drawCoins,
+  bucket: drawBucket,
+  ladder: drawLadder
+});
+
+function backgroundDecorations(seed, c) {
+  const value = hashString(seed);
+  const circles = [
+    { cx: 82 + (value % 48), cy: 290 + ((value >>> 4) % 100), r: 18, fill: c.primary },
+    { cx: 630 - ((value >>> 8) % 55), cy: 420 + ((value >>> 12) % 100), r: 11, fill: c.secondary },
+    { cx: 104 + ((value >>> 16) % 42), cy: 910 - ((value >>> 20) % 50), r: 9, fill: c.good },
+    { cx: 612 - ((value >>> 24) % 50), cy: 870 - (value % 54), r: 15, fill: c.danger }
+  ];
+  return circles.map(circle => (
+    `<circle cx="${circle.cx}" cy="${circle.cy}" r="${circle.r}" fill="${circle.fill}" opacity="0.8"/>`
+  )).join('');
+}
+
+function buildIllustrationSvg(options = {}, overrides = {}) {
+  const config = typeof options === 'string' ? { ...overrides, kind: options } : (options || {});
+  const kind = normalizeKind(config.kind);
+  const seed = String(config.seed || `${kind}:${config.title || ''}:${config.detail || ''}`);
+  const palette = config.palette || getPalette(seed);
+  const c = colorsFor(palette);
+  const titleLines = wrapText(config.title || kind, 25).slice(0, 2);
+  const detailLines = wrapText(config.detail || 'Topic-specific local illustration', 43).slice(0, 2);
+  const titleSvg = titleLines.map((line, index) => (
+    `<tspan x="70" dy="${index === 0 ? 0 : 43}">${escapeXml(line)}</tspan>`
+  )).join('');
+  const detailSvg = detailLines.map((line, index) => (
+    `<tspan x="78" dy="${index === 0 ? 0 : 38}">${escapeXml(line)}</tspan>`
+  )).join('');
+  const renderer = KIND_RENDERERS[kind];
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+    <svg width="${ILLUSTRATION_WIDTH}" height="${ILLUSTRATION_HEIGHT}" viewBox="0 0 ${ILLUSTRATION_WIDTH} ${ILLUSTRATION_HEIGHT}" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0" stop-color="${c.background}"/>
+          <stop offset="1" stop-color="${c.panel}"/>
+        </linearGradient>
+        <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+          <feDropShadow dx="0" dy="12" stdDeviation="10" flood-color="#000000" flood-opacity="0.28"/>
+        </filter>
+      </defs>
+      <rect width="${ILLUSTRATION_WIDTH}" height="${ILLUSTRATION_HEIGHT}" fill="url(#background)"/>
+      ${backgroundDecorations(seed, c)}
+      <rect x="54" y="48" width="612" height="116" rx="28" fill="${c.panel}" opacity="0.92"/>
+      <text x="70" y="88" fill="${c.primary}" font-family="Arial, sans-serif" font-size="22" font-weight="900" letter-spacing="2">LOCAL 2D CARTOON</text>
+      <text x="70" y="126" fill="${c.ink}" font-family="Arial, sans-serif" font-size="29" font-weight="800">${titleSvg}</text>
+      <rect x="54" y="210" width="612" height="730" rx="44" fill="${c.panel}" opacity="0.96" filter="url(#shadow)"/>
+      <g transform="translate(360 580)">${renderer(c)}</g>
+      <rect x="54" y="1000" width="612" height="174" rx="30" fill="${c.panel}" opacity="0.94"/>
+      <text x="78" y="1044" fill="${c.secondary}" font-family="Arial, sans-serif" font-size="20" font-weight="900" letter-spacing="2">${escapeXml(kind.toUpperCase())} PANEL</text>
+      <text x="78" y="1093" fill="${c.ink}" font-family="Arial, sans-serif" font-size="27" font-weight="700">${detailSvg}</text>
+      <text x="78" y="1220" fill="${c.muted}" font-family="Arial, sans-serif" font-size="20" font-weight="600">Educational illustration | No guaranteed returns</text>
+    </svg>`;
+}
+
+async function createCartoonIllustration(optionsOrKind, outputPath, metadata = {}) {
+  const config = typeof optionsOrKind === 'string'
+    ? { ...metadata, kind: optionsOrKind, outputPath }
+    : (optionsOrKind || {});
+  if (!config.outputPath) throw new Error('outputPath is required for a cartoon illustration');
+
+  await fs.mkdir(path.dirname(config.outputPath), { recursive: true });
+  await sharp(Buffer.from(buildIllustrationSvg(config)))
+    .png()
+    .toFile(config.outputPath);
+  return config.outputPath;
+}
+
+async function createCartoonIllustrations(scenes, outputDir, options = {}) {
+  if (!Array.isArray(scenes) || scenes.length === 0) {
+    throw new Error('At least one scene is required for cartoon illustrations');
+  }
+  if (!outputDir) throw new Error('outputDir is required for cartoon illustrations');
+
+  const topicKey = options.topicKey || 'topic';
+  const illustrations = [];
+  for (let index = 0; index < scenes.length; index += 1) {
+    const scene = scenes[index] || {};
+    const outputPath = path.join(outputDir, `panel_${String(index + 1).padStart(2, '0')}.png`);
+    const title = scene.title || scene.label || scene.heading || `Scene ${index + 1}`;
+    const detail = scene.detail || scene.subtitle || scene.caption || '';
+    const kind = normalizeKind(scene.kind);
+    await createCartoonIllustration({
+      kind,
+      title,
+      detail,
+      outputPath,
+      palette: scene.palette,
+      seed: `${topicKey}:${index}:${kind}:${title}:${detail}`
+    });
+    illustrations.push(outputPath);
+  }
+  return illustrations;
+}
+
+module.exports = {
+  ILLUSTRATION_HEIGHT,
+  ILLUSTRATION_WIDTH,
+  PALETTES,
+  SUPPORTED_KINDS,
+  buildIllustrationSvg,
+  createCartoonIllustration,
+  createCartoonIllustrations,
+  escapeXml,
+  getPalette,
+  hashString,
+  isSupportedKind,
+  normalizeKind,
+  wrapText
+};

--- a/utils/credential-manager.js
+++ b/utils/credential-manager.js
@@ -105,9 +105,9 @@ class CredentialManager {
     const scopes = [
       'https://www.googleapis.com/auth/youtube.upload',
       'https://www.googleapis.com/auth/youtube',
+      'https://www.googleapis.com/auth/youtube.force-ssl',
       'https://www.googleapis.com/auth/youtube.readonly',
-      'https://www.googleapis.com/auth/yt-analytics.readonly',
-      'https://www.googleapis.com/auth/youtube.force-ssl'
+      'https://www.googleapis.com/auth/yt-analytics.readonly'
     ];
 
     const authUrl = oauth2Client.generateAuthUrl({
@@ -513,13 +513,18 @@ class CredentialManager {
   }
   // Validation methods
   hasAITextProvider() {
-    if (this.credentials.openai?.apiKey || this.credentials.gemini?.apiKey || this.credentials.aiProvider?.apiKey) {
+    if (
+      this.credentials.openai?.apiKey ||
+      this.credentials.gemini?.apiKey ||
+      this.credentials.anthropic?.apiKey ||
+      this.credentials.aiProvider?.apiKey
+    ) {
       return true;
     }
 
     // Environment-variable based configuration (see utils/ai-text-service.js)
     const envKeys = [...Object.values(PROVIDERS).map(p => p.envKey), 'GEMINI_API_KEY'];
-    return envKeys.some(key => process.env[key]);
+    return envKeys.some(key => process.env[key]) || Boolean(process.env.ANTHROPIC_API_KEY);
   }
 
   getMissingCredentials() {
@@ -636,6 +641,7 @@ class CredentialManager {
         choices: [
           { name: 'OpenAI (GPT-5.6)', value: 'openai' },
           { name: 'Google Gemini (Gemini 3.7)', value: 'gemini' },
+          { name: 'Anthropic Claude', value: 'anthropic' },
           { name: 'OpenRouter (400+ models, one API key)', value: 'openrouter' },
           { name: 'Kimi (Moonshot AI — K3)', value: 'kimi' },
           { name: 'MiMo (Xiaomi — V2.5 Pro)', value: 'mimo' },
@@ -647,11 +653,41 @@ class CredentialManager {
     switch (service) {
       case 'openai': return await this.setupOpenAICredentials();
       case 'gemini': return await this.setupGeminiCredentials();
+      case 'anthropic': return await this.setupAnthropicCredentials();
       case 'openrouter': return await this.setupOpenRouterCredentials();
       case 'kimi': return await this.setupKimiCredentials();
       case 'mimo': return await this.setupMiMoCredentials();
       case 'glm': return await this.setupGLMCredentials();
     }
+  }
+
+  async setupAnthropicCredentials() {
+    console.log(chalk.cyan('\n🧠 Anthropic Claude Setup'));
+    console.log(chalk.gray('Get your API key from: https://console.anthropic.com/settings/keys'));
+
+    const answers = await inquirer.prompt([
+      {
+        type: 'password',
+        name: 'apiKey',
+        message: 'Enter your Anthropic API Key:',
+        validate: input => input.length > 0 || 'API key is required'
+      },
+      {
+        type: 'input',
+        name: 'model',
+        message: 'Enter the Claude model ID:',
+        default: process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-5',
+        validate: input => input.trim().length > 0 || 'Model ID is required'
+      }
+    ]);
+
+    this.credentials.anthropic = {
+      apiKey: answers.apiKey,
+      model: answers.model.trim()
+    };
+
+    await this.saveCredentials();
+    console.log(chalk.green('✅ Anthropic Claude configured successfully!'));
   }
 
   async setupTTSService() {

--- a/utils/ffmpeg.js
+++ b/utils/ffmpeg.js
@@ -1,9 +1,21 @@
-const { execFile } = require('child_process');
+const { execFile, spawn } = require('child_process');
+const fs = require('fs');
+const path = require('path');
 const { promisify } = require('util');
 
 const execFileAsync = promisify(execFile);
 
 let cachedPath = null;
+
+function findSystemFFmpeg() {
+  const executable = process.platform === 'win32' ? 'ffmpeg.exe' : 'ffmpeg';
+  const pathValue = process.env.PATH || process.env.Path || '';
+  const directories = pathValue.split(path.delimiter).filter(Boolean);
+  const match = directories
+    .map(directory => path.join(directory, executable))
+    .find(candidate => fs.existsSync(candidate));
+  return match || 'ffmpeg';
+}
 
 /**
  * Resolve the FFmpeg binary to use, in order of preference:
@@ -22,12 +34,13 @@ function getFFmpegPath() {
   }
 
   try {
-    cachedPath = require('ffmpeg-static');
-  } catch (error) {
+    const bundledPath = require('ffmpeg-static');
+    cachedPath = bundledPath && fs.existsSync(bundledPath) ? bundledPath : null;
+  } catch {
     cachedPath = null;
   }
 
-  cachedPath = cachedPath || 'ffmpeg';
+  cachedPath = cachedPath || findSystemFFmpeg();
   return cachedPath;
 }
 
@@ -35,13 +48,58 @@ async function checkFFmpeg() {
   try {
     await execFileAsync(getFFmpegPath(), ['-version']);
     return true;
-  } catch (error) {
+  } catch {
     return false;
   }
 }
 
 async function runFFmpeg(args) {
-  return execFileAsync(getFFmpegPath(), args, { maxBuffer: 32 * 1024 * 1024 });
+  return new Promise((resolve, reject) => {
+    const child = spawn(getFFmpegPath(), args, { windowsHide: true });
+    const stdout = [];
+    const stderr = [];
+    let outputBytes = 0;
+    let spawnError = null;
+    let outputLimitError = null;
+
+    const collect = (target, chunk) => {
+      outputBytes += chunk.length;
+      if (outputBytes > 32 * 1024 * 1024 && !outputLimitError) {
+        outputLimitError = new Error('FFmpeg output exceeded the 32 MB limit');
+        child.kill();
+        return;
+      }
+      target.push(chunk);
+    };
+
+    child.stdout.on('data', chunk => collect(stdout, chunk));
+    child.stderr.on('data', chunk => collect(stderr, chunk));
+    child.once('error', error => {
+      spawnError = error;
+    });
+    child.once('close', (code, signal) => {
+      const stdoutText = Buffer.concat(stdout).toString();
+      const stderrText = Buffer.concat(stderr).toString();
+      if (spawnError) {
+        spawnError.stdout = stdoutText;
+        spawnError.stderr = stderrText;
+        reject(spawnError);
+      } else if (outputLimitError) {
+        outputLimitError.stdout = stdoutText;
+        outputLimitError.stderr = stderrText;
+        reject(outputLimitError);
+      } else if (code !== 0) {
+        const error = new Error(`FFmpeg exited with code ${code}${signal ? ` (${signal})` : ''}`);
+        error.code = code;
+        error.signal = signal;
+        error.stdout = stdoutText;
+        error.stderr = stderrText;
+        reject(error);
+      } else {
+        resolve({ stdout: stdoutText, stderr: stderrText });
+      }
+    });
+  });
 }
 
 function ffmpegInstallHint() {

--- a/utils/local-tts.js
+++ b/utils/local-tts.js
@@ -1,0 +1,80 @@
+const { spawn } = require('child_process');
+const fs = require('fs').promises;
+const path = require('path');
+const { runFFmpeg } = require('./ffmpeg');
+
+function canUseWindowsSpeech() {
+  return process.platform === 'win32';
+}
+
+function runPowerShellSpeech(text, wavPath) {
+  const script = [
+    '$ErrorActionPreference = "Stop"',
+    'Add-Type -AssemblyName System.Speech',
+    '$synth = New-Object System.Speech.Synthesis.SpeechSynthesizer',
+    '$synth.Rate = 0',
+    '$synth.Volume = 100',
+    '$synth.SetOutputToWaveFile($env:YAA_TTS_OUTPUT)',
+    '$synth.Speak([Console]::In.ReadToEnd())',
+    '$synth.Dispose()'
+  ].join('; ');
+
+  return new Promise((resolve, reject) => {
+    const child = spawn('powershell.exe', [
+      '-NoProfile',
+      '-NonInteractive',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-Command',
+      script
+    ], {
+      windowsHide: true,
+      env: { ...process.env, YAA_TTS_OUTPUT: wavPath },
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+    const stderr = [];
+    let spawnError = null;
+
+    child.stderr.on('data', chunk => stderr.push(chunk));
+    child.once('error', error => {
+      spawnError = error;
+    });
+    child.once('close', code => {
+      if (spawnError) {
+        reject(spawnError);
+      } else if (code !== 0) {
+        reject(new Error(`Windows Speech exited with code ${code}: ${Buffer.concat(stderr).toString().trim()}`));
+      } else {
+        resolve();
+      }
+    });
+
+    child.stdin.end(text);
+  });
+}
+
+async function generateWindowsSpeech(text, outputPath) {
+  if (!canUseWindowsSpeech()) {
+    throw new Error('Windows System.Speech is only available on Windows');
+  }
+
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  const wavPath = `${outputPath}.wav`;
+  try {
+    await runPowerShellSpeech(text, wavPath);
+    await runFFmpeg([
+      '-y',
+      '-i', wavPath,
+      '-codec:a', 'libmp3lame',
+      '-q:a', '4',
+      outputPath
+    ]);
+    const stats = await fs.stat(outputPath);
+    if (!stats.isFile() || stats.size === 0) throw new Error('Windows Speech produced an empty audio file');
+    return outputPath;
+  } finally {
+    await fs.rm(wavPath, { force: true }).catch(() => {});
+  }
+}
+
+module.exports = { canUseWindowsSpeech, generateWindowsSpeech };

--- a/utils/short-video-renderer.js
+++ b/utils/short-video-renderer.js
@@ -1,0 +1,472 @@
+const fs = require('fs').promises;
+const path = require('path');
+const sharp = require('sharp');
+const { runFFmpeg } = require('./ffmpeg');
+
+const SHORT_WIDTH = 1080;
+const SHORT_HEIGHT = 1920;
+const MOTION_WIDTH = 720;
+const MOTION_HEIGHT = 1280;
+const DEFAULT_FPS = 30;
+const DEFAULT_FADE_DURATION = 0.45;
+const DEFAULT_CAPTION_WORDS = 6;
+
+function escapeXml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function wrapText(value, maxCharacters) {
+  const words = String(value ?? '').trim().split(/\s+/).filter(Boolean);
+  const lines = [];
+  let line = '';
+
+  for (const word of words) {
+    const candidate = line ? `${line} ${word}` : word;
+    if (line && candidate.length > maxCharacters) {
+      lines.push(line);
+      line = word;
+    } else {
+      line = candidate;
+    }
+  }
+
+  if (line) lines.push(line);
+  return lines;
+}
+
+function sceneText(scene = {}, fallbackIndex = 0) {
+  if (typeof scene === 'string') {
+    return { title: scene, detail: '', accent: '#f6c75d', index: fallbackIndex };
+  }
+
+  return {
+    title: scene.title || scene.label || scene.heading || `Finance beat ${fallbackIndex + 1}`,
+    detail: scene.detail || scene.subtitle || scene.caption || scene.text || '',
+    accent: scene.accent || '#f6c75d',
+    index: fallbackIndex
+  };
+}
+
+function cardOverlay(scene, index, width = SHORT_WIDTH, height = SHORT_HEIGHT) {
+  const text = sceneText(scene, index);
+  const titleLines = wrapText(text.title, 20).slice(0, 3);
+  const detailLines = wrapText(text.detail, 28).slice(0, 4);
+  const titleY = height - (detailLines.length ? 610 : 470);
+  const detailY = titleY + 94;
+  const accent = escapeXml(text.accent);
+
+  const titleSvg = titleLines.map((line, lineIndex) => (
+    `<tspan x="76" dy="${lineIndex === 0 ? 0 : 70}">${escapeXml(line)}</tspan>`
+  )).join('');
+  const detailSvg = detailLines.map((line, lineIndex) => (
+    `<tspan x="76" dy="${lineIndex === 0 ? 0 : 48}">${escapeXml(line)}</tspan>`
+  )).join('');
+
+  return `
+    <svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <linearGradient id="shade" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stop-color="#061323" stop-opacity="0.06"/>
+          <stop offset="0.58" stop-color="#061323" stop-opacity="0.16"/>
+          <stop offset="1" stop-color="#061323" stop-opacity="0.96"/>
+        </linearGradient>
+        <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+          <feDropShadow dx="0" dy="5" stdDeviation="5" flood-color="#000000" flood-opacity="0.72"/>
+        </filter>
+      </defs>
+      <rect width="${width}" height="${height}" fill="url(#shade)"/>
+      <rect x="76" y="78" width="350" height="76" rx="18" fill="${accent}"/>
+      <text x="104" y="128" fill="#071522" font-family="Arial, sans-serif" font-size="32px" font-weight="900">MONEY MINUTE</text>
+      <text x="76" y="${titleY}" fill="#ffffff" font-family="Arial, sans-serif" font-size="66px" font-weight="900" filter="url(#shadow)">${titleSvg}</text>
+      ${detailLines.length ? `<text x="76" y="${detailY}" fill="${accent}" font-family="Arial, sans-serif" font-size="42px" font-weight="700" filter="url(#shadow)">${detailSvg}</text>` : ''}
+      <text x="76" y="${height - 76}" fill="#e6edf5" font-family="Arial, sans-serif" font-size="25px" font-weight="600" opacity="0.92">Education only | No guaranteed returns</text>
+    </svg>`;
+}
+
+function getSourceValue(source) {
+  if (typeof source === 'string' || Buffer.isBuffer(source)) return source;
+  if (source && (typeof source.path === 'string' || Buffer.isBuffer(source.path))) return source.path;
+  throw new Error('Each Short source image must be a file path, Buffer, or { path } object');
+}
+
+async function createVerticalCard(source, scene, outputPath, options = {}) {
+  const index = Number.isInteger(options.index) ? options.index : 0;
+  const positions = ['centre', 'north', 'south', 'east', 'west'];
+  const position = options.position || positions[index % positions.length];
+  const brightness = Number.isFinite(options.brightness)
+    ? options.brightness
+    : 0.96 + ((index % 4) * 0.025);
+  const saturation = Number.isFinite(options.saturation)
+    ? options.saturation
+    : 0.92 + ((index % 3) * 0.06);
+
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  let image = sharp(getSourceValue(source))
+    .resize(SHORT_WIDTH, SHORT_HEIGHT, { fit: 'cover', position })
+    .modulate({ brightness, saturation });
+
+  if (options.sharpen !== false) image = image.sharpen(0.6);
+
+  await image
+    .composite([{ input: Buffer.from(cardOverlay(scene, index)) }])
+    .removeAlpha()
+    .png()
+    .toFile(outputPath);
+
+  return outputPath;
+}
+
+/**
+ * Create one local vertical card per scene. Callers can provide a dedicated
+ * source for every beat; the renderer itself never invokes an image or
+ * animation API.
+ */
+async function createVerticalCards(sourceImages, scenes, outputDir, options = {}) {
+  if (!Array.isArray(sourceImages) || sourceImages.length === 0) {
+    throw new Error('At least one source image is required to create Short cards');
+  }
+  if (!Array.isArray(scenes) || scenes.length === 0) {
+    throw new Error('At least one scene is required to create Short cards');
+  }
+
+  const cards = [];
+  for (let index = 0; index < scenes.length; index += 1) {
+    const outputPath = path.join(outputDir, `card_${String(index + 1).padStart(2, '0')}.png`);
+    const source = sourceImages[index % sourceImages.length];
+    await createVerticalCard(source, scenes[index], outputPath, { ...options, index });
+    cards.push(outputPath);
+  }
+
+  return cards;
+}
+
+function splitWords(text) {
+  return String(text ?? '').trim().split(/\s+/).filter(Boolean);
+}
+
+function chunkWords(textOrWords, maxWords = DEFAULT_CAPTION_WORDS) {
+  const words = Array.isArray(textOrWords) ? textOrWords.filter(Boolean) : splitWords(textOrWords);
+  const size = Math.max(1, Math.floor(Number(maxWords) || DEFAULT_CAPTION_WORDS));
+  const chunks = [];
+
+  for (let index = 0; index < words.length; index += size) {
+    chunks.push(words.slice(index, index + size));
+  }
+
+  return chunks;
+}
+
+function formatSrtTime(seconds) {
+  const milliseconds = Math.max(0, Math.round(Number(seconds) * 1000));
+  const hours = Math.floor(milliseconds / 3600000);
+  const minutes = Math.floor((milliseconds % 3600000) / 60000);
+  const wholeSeconds = Math.floor((milliseconds % 60000) / 1000);
+  const remainder = milliseconds % 1000;
+
+  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${String(wholeSeconds).padStart(2, '0')},${String(remainder).padStart(3, '0')}`;
+}
+
+function createSrtCaptions(text, duration, options = {}) {
+  const words = splitWords(text);
+  const totalDuration = Number(duration);
+  if (words.length === 0) return '';
+  if (!Number.isFinite(totalDuration) || totalDuration <= 0) {
+    throw new Error('Caption duration must be a positive number');
+  }
+
+  const chunks = chunkWords(words, options.maxWords || DEFAULT_CAPTION_WORDS);
+  let wordCursor = 0;
+  return chunks.map((chunk, index) => {
+    const start = totalDuration * (wordCursor / words.length);
+    wordCursor += chunk.length;
+    const end = index === chunks.length - 1
+      ? totalDuration
+      : totalDuration * (wordCursor / words.length);
+    return `${index + 1}\n${formatSrtTime(start)} --> ${formatSrtTime(end)}\n${chunk.join(' ')}\n`;
+  }).join('\n');
+}
+
+function estimateNarrationDuration(text, wordsPerMinute = 150) {
+  const words = splitWords(text).length;
+  const rate = Math.max(1, Number(wordsPerMinute) || 150);
+  return Math.max(1, (words / rate) * 60);
+}
+
+function parseDuration(text) {
+  const match = String(text || '').match(/Duration:\s+(\d+):(\d+):(\d+(?:\.\d+)?)/i);
+  if (!match) return null;
+  return Number(match[1]) * 3600 + Number(match[2]) * 60 + Number(match[3]);
+}
+
+async function probeAudioDuration(audioPath) {
+  let output = '';
+  try {
+    const result = await runFFmpeg(['-hide_banner', '-i', audioPath, '-f', 'null', '-']);
+    output = `${result.stdout || ''}\n${result.stderr || ''}`;
+  } catch (error) {
+    output = `${error.stdout || ''}\n${error.stderr || ''}`;
+  }
+
+  const duration = parseDuration(output);
+  if (!duration || duration <= 0) {
+    throw new Error(`Could not measure narration duration: ${audioPath}`);
+  }
+  return duration;
+}
+
+async function isUsableAudioFile(audioPath) {
+  if (typeof audioPath !== 'string' || audioPath.endsWith('.info')) return false;
+  try {
+    const stats = await fs.stat(audioPath);
+    return stats.isFile() && stats.size > 0;
+  } catch {
+    return false;
+  }
+}
+
+function getEffectiveFadeDuration(totalDuration, cardCount, requested = DEFAULT_FADE_DURATION) {
+  const safeRequested = Math.max(0.1, Number(requested) || DEFAULT_FADE_DURATION);
+  if (cardCount <= 1) return 0;
+  return Math.min(safeRequested, Math.max(0.1, totalDuration / (cardCount * 2)));
+}
+
+function sceneWeight(scene) {
+  const explicit = Number(scene?.duration);
+  if (Number.isFinite(explicit) && explicit > 0) return explicit;
+  const text = scene?.caption || scene?.detail || scene?.subtitle || scene?.title || '';
+  return Math.max(1, splitWords(text).length);
+}
+
+function calculateCardDurations(totalDuration, scenes, fadeDuration = DEFAULT_FADE_DURATION) {
+  const duration = Number(totalDuration);
+  if (!Number.isFinite(duration) || duration <= 0) throw new Error('Video duration must be positive');
+  if (!Array.isArray(scenes) || scenes.length === 0) throw new Error('At least one scene is required');
+
+  const fade = getEffectiveFadeDuration(duration, scenes.length, fadeDuration);
+  const available = duration + (fade * Math.max(0, scenes.length - 1));
+  const weights = scenes.map(sceneWeight);
+  const totalWeight = weights.reduce((sum, value) => sum + value, 0);
+  return {
+    durations: weights.map(weight => available * (weight / totalWeight)),
+    fadeDuration: fade,
+    totalDuration: duration
+  };
+}
+
+function escapeSubtitleFilterPath(filePath) {
+  const normalized = path.resolve(filePath).replace(/\\/g, '/');
+  return normalized
+    .replace(/\\/g, '\\\\')
+    .replace(/:/g, '\\:')
+    .replace(/'/g, "\\'")
+    .replace(/,/g, '\\,');
+}
+
+function escapeFilterStyle(value) {
+  return String(value)
+    .replace(/\\/g, '\\\\')
+    .replace(/'/g, "\\'");
+}
+
+function buildSubtitleFilter(srtPath, forceStyle) {
+  const style = forceStyle || 'FontName=Arial,FontSize=18,PrimaryColour=&H00FFFFFF,OutlineColour=&H80000000,BorderStyle=1,Outline=2,Shadow=1,Alignment=2,MarginV=140';
+  return `subtitles=filename='${escapeSubtitleFilterPath(srtPath)}':force_style='${escapeFilterStyle(style)}'`;
+}
+
+function kenBurnsFilter(index, duration, fadeFps = DEFAULT_FPS) {
+  const frames = Math.max(1, Math.ceil(duration * fadeFps));
+  const increment = (0.045 / frames).toFixed(8);
+  const direction = index % 4;
+  let x;
+  let y;
+
+  if (direction === 0) {
+    x = `(iw-iw/zoom)*on/${frames}`;
+    y = `(ih-ih/zoom)*on/${frames}`;
+  } else if (direction === 1) {
+    x = `(iw-iw/zoom)*(1-on/${frames})`;
+    y = `(ih-ih/zoom)*on/${frames}`;
+  } else if (direction === 2) {
+    x = `(iw-iw/zoom)*on/${frames}`;
+    y = `(ih-ih/zoom)*(1-on/${frames})`;
+  } else {
+    x = `(iw-iw/zoom)*(1-on/${frames})`;
+    y = `(ih-ih/zoom)*(1-on/${frames})`;
+  }
+
+  return `zoompan=z=min(zoom+${increment}\\,1.045):x=${x}:y=${y}:d=1:s=${MOTION_WIDTH}x${MOTION_HEIGHT}:fps=${fadeFps},scale=${SHORT_WIDTH}:${SHORT_HEIGHT}:flags=bilinear,format=yuv420p,setsar=1`;
+}
+
+async function renderMotionVideo(cards, durations, fadeDuration, outputPath, options = {}) {
+  if (!Array.isArray(cards) || cards.length === 0) throw new Error('No cards to render');
+  if (cards.length !== durations.length) throw new Error('Card and duration counts do not match');
+
+  const fps = Number(options.fps) || DEFAULT_FPS;
+  const motionDir = `${outputPath}.motion-cards`;
+  await fs.mkdir(motionDir, { recursive: true });
+
+  try {
+    const motionCards = [];
+    for (let index = 0; index < cards.length; index += 1) {
+      const motionCard = path.join(motionDir, `motion_${String(index + 1).padStart(2, '0')}.png`);
+      await sharp(cards[index])
+        .resize(MOTION_WIDTH, MOTION_HEIGHT, { fit: 'fill' })
+        .removeAlpha()
+        .png()
+        .toFile(motionCard);
+      motionCards.push(motionCard);
+    }
+
+    const args = ['-y', '-nostdin', '-loglevel', 'error'];
+    for (let index = 0; index < motionCards.length; index += 1) {
+      args.push('-loop', '1', '-framerate', String(fps), '-t', durations[index].toFixed(4), '-i', motionCards[index]);
+    }
+
+    const filters = cards.map((_, index) => (
+      `[${index}:v]${kenBurnsFilter(index, durations[index], fps)}[v${index}]`
+    ));
+    let current = '[v0]';
+    for (let index = 1; index < cards.length; index += 1) {
+      const offset = durations.slice(0, index).reduce((sum, value) => sum + value, 0) - (index * fadeDuration);
+      const output = `[xf${index}]`;
+      filters.push(`${current}[v${index}]xfade=transition=fade:duration=${fadeDuration.toFixed(4)}:offset=${offset.toFixed(4)}${output}`);
+      current = output;
+    }
+    filters.push(`${current}format=yuv420p[vfinal]`);
+    const outputDuration = durations.reduce((sum, value) => sum + value, 0)
+      - (fadeDuration * Math.max(0, cards.length - 1));
+
+    args.push(
+      '-filter_complex', filters.join(';'),
+      '-map', '[vfinal]',
+      '-an',
+      '-r', String(fps),
+      '-c:v', 'libx264',
+      '-preset', options.preset || 'veryfast',
+      '-crf', String(options.crf || 20),
+      '-pix_fmt', 'yuv420p',
+      '-t', outputDuration.toFixed(4),
+      '-frames:v', String(Math.max(1, Math.ceil(outputDuration * fps))),
+      outputPath
+    );
+    await runFFmpeg(args);
+  } finally {
+    await fs.rm(motionDir, { recursive: true, force: true }).catch(() => {});
+  }
+  return outputPath;
+}
+
+async function burnCaptionsAndAudio(visualPath, audioPath, srtPath, outputPath, duration, options = {}) {
+  const hasAudio = await isUsableAudioFile(audioPath);
+  const args = ['-y', '-nostdin', '-loglevel', 'error', '-i', visualPath];
+  if (hasAudio) args.push('-i', audioPath);
+
+  args.push(
+    '-vf', buildSubtitleFilter(srtPath, options.forceStyle),
+    '-map', '0:v:0',
+    '-c:v', 'libx264',
+    '-preset', options.preset || 'veryfast',
+    '-crf', String(options.crf || 20),
+    '-pix_fmt', 'yuv420p'
+  );
+
+  if (hasAudio) {
+    args.push('-map', '1:a:0', '-c:a', 'aac', '-b:a', '128k', '-shortest');
+  } else {
+    args.push('-an', '-t', String(duration));
+  }
+
+  args.push('-movflags', '+faststart', outputPath);
+  await runFFmpeg(args);
+  return outputPath;
+}
+
+async function renderShortVideo(options = {}) {
+  const {
+    sourceImages,
+    scenes,
+    narrationText,
+    audioPath,
+    outputPath,
+    srtPath = outputPath && outputPath.replace(/\.mp4$/i, '.srt'),
+    cardsDir = outputPath && path.join(path.dirname(outputPath), 'cards'),
+    allowSilent = false
+  } = options;
+
+  if (!outputPath) throw new Error('outputPath is required');
+  if (!narrationText || splitWords(narrationText).length === 0) throw new Error('narrationText is required');
+  if (!srtPath || !cardsDir) throw new Error('srtPath and cardsDir are required');
+
+  const audioAvailable = await isUsableAudioFile(audioPath);
+  let measuredDuration;
+  if (audioAvailable) {
+    measuredDuration = await probeAudioDuration(audioPath);
+  } else if (!allowSilent) {
+    throw new Error('A usable narration audio file is required; pass allowSilent only for an intentional silent preview');
+  } else {
+    measuredDuration = Number(options.duration) > 0
+      ? Number(options.duration)
+      : estimateNarrationDuration(narrationText);
+  }
+
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.mkdir(path.dirname(srtPath), { recursive: true });
+  await fs.writeFile(
+    srtPath,
+    createSrtCaptions(narrationText, measuredDuration, { maxWords: options.captionMaxWords }),
+    'utf8'
+  );
+
+  const cards = await createVerticalCards(sourceImages, scenes, cardsDir, options.cardOptions);
+  const timing = calculateCardDurations(measuredDuration, scenes, options.fadeDuration);
+  const visualPath = options.visualPath || outputPath.replace(/\.mp4$/i, '_visual.mp4');
+
+  try {
+    await renderMotionVideo(cards, timing.durations, timing.fadeDuration, visualPath, options);
+    await burnCaptionsAndAudio(visualPath, audioAvailable ? audioPath : null, srtPath, outputPath, measuredDuration, options);
+  } finally {
+    if (!options.keepVisual) await fs.rm(visualPath, { force: true }).catch(() => {});
+  }
+
+  return {
+    outputPath,
+    srtPath,
+    cards,
+    duration: measuredDuration,
+    durations: timing.durations,
+    fadeDuration: timing.fadeDuration,
+    audioPath: audioAvailable ? audioPath : null,
+    silent: !audioAvailable
+  };
+}
+
+module.exports = {
+  SHORT_WIDTH,
+  SHORT_HEIGHT,
+  buildSubtitleFilter,
+  calculateCardDurations,
+  cardOverlay,
+  chunkWords,
+  createCaptions: createSrtCaptions,
+  createSrtCaptions,
+  createVerticalCard,
+  createVerticalCards,
+  escapeSubtitleFilterPath,
+  escapeSubtitlePath: escapeSubtitleFilterPath,
+  estimateNarrationDuration,
+  formatSrtTime,
+  formatTimestamp: formatSrtTime,
+  getEffectiveFadeDuration,
+  isUsableAudioFile,
+  kenBurnsFilter,
+  measureAudioDuration: probeAudioDuration,
+  probeAudioDuration,
+  renderMotionVideo,
+  renderShort: renderShortVideo,
+  renderShortVideo
+};

--- a/utils/youtube-rate-limit.js
+++ b/utils/youtube-rate-limit.js
@@ -1,0 +1,299 @@
+const fs = require('fs').promises;
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const DEFAULT_STATE_PATH = path.join(ROOT, 'data', 'youtube-rate-limit.json');
+const DEFAULT_LOCK_PATH = path.join(ROOT, 'data', '.youtube-rate-limit.lock');
+const DEFAULT_LIMIT = 20;
+const HARD_LIMIT = 20;
+const DEFAULT_LOCK_TIMEOUT_MS = 30000;
+const DEFAULT_STALE_LOCK_MS = 60000;
+
+function getDailyLimit(options = {}) {
+  const configured = options.limit ?? process.env.YOUTUBE_PUBLIC_SHORTS_PER_DAY;
+  const parsed = Number(configured);
+  if (!Number.isFinite(parsed)) return DEFAULT_LIMIT;
+  return Math.max(1, Math.min(HARD_LIMIT, Math.floor(parsed)));
+}
+
+function isExplicitShort(metadata = {}) {
+  const candidates = [metadata, metadata.video, metadata.metadata].filter(Boolean);
+  return candidates.some(candidate => candidate.isShort === true
+    || String(candidate.contentType || '').toLowerCase() === 'short'
+    || candidate.aspectRatio === '9:16');
+}
+
+function getTimeZone(options = {}) {
+  return options.timeZone || process.env.YOUTUBE_RATE_LIMIT_TIMEZONE || 'UTC';
+}
+
+function getDateKey(date = new Date(), timeZone = getTimeZone()) {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+  });
+  const parts = Object.fromEntries(formatter.formatToParts(date).map(part => [part.type, part.value]));
+  return `${parts.year}-${parts.month}-${parts.day}`;
+}
+
+function getPaths(options = {}) {
+  const statePath = path.resolve(options.statePath || DEFAULT_STATE_PATH);
+  const lockPath = path.resolve(options.lockPath || DEFAULT_LOCK_PATH);
+  return { statePath, lockPath };
+}
+
+function emptyState() {
+  return { version: 1, days: {} };
+}
+
+function normalizeState(state) {
+  if (!state || typeof state !== 'object') return emptyState();
+  if (!state.days || typeof state.days !== 'object') state.days = {};
+  state.version = 1;
+  return state;
+}
+
+async function readState(statePath) {
+  try {
+    return normalizeState(JSON.parse(await fs.readFile(statePath, 'utf8')));
+  } catch (error) {
+    if (error.code === 'ENOENT') return emptyState();
+    throw new Error(`Could not read YouTube rate-limit state: ${error.message}`);
+  }
+}
+
+async function writeState(statePath, state) {
+  await fs.mkdir(path.dirname(statePath), { recursive: true });
+  const temporaryPath = `${statePath}.${process.pid}.${Date.now()}.tmp`;
+  await fs.writeFile(temporaryPath, JSON.stringify(state, null, 2), 'utf8');
+  try {
+    await fs.rename(temporaryPath, statePath);
+  } catch {
+    await fs.rm(statePath, { force: true }).catch(() => {});
+    await fs.rename(temporaryPath, statePath);
+  }
+}
+
+function sleep(milliseconds) {
+  return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
+async function lockIsStale(lockPath, staleMs) {
+  try {
+    const stats = await fs.stat(lockPath);
+    return Date.now() - stats.mtimeMs > staleMs;
+  } catch (error) {
+    return error.code !== 'ENOENT';
+  }
+}
+
+async function acquireLock(lockPath, options = {}) {
+  await fs.mkdir(path.dirname(lockPath), { recursive: true });
+  const timeoutMs = Math.max(1000, Number(options.lockTimeoutMs) || DEFAULT_LOCK_TIMEOUT_MS);
+  const staleMs = Math.max(1000, Number(options.staleLockMs) || DEFAULT_STALE_LOCK_MS);
+  const startedAt = Date.now();
+  const token = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const ownerPath = path.join(lockPath, 'owner');
+
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      await fs.mkdir(lockPath);
+      await fs.writeFile(ownerPath, token, 'utf8');
+      return async () => {
+        try {
+          const owner = await fs.readFile(ownerPath, 'utf8');
+          if (owner === token) await fs.rm(lockPath, { recursive: true, force: true });
+        } catch (error) {
+          if (error.code === 'ENOENT') return;
+          throw error;
+        }
+      };
+    } catch (error) {
+      if (error.code !== 'EEXIST') throw error;
+      if (await lockIsStale(lockPath, staleMs)) {
+        await fs.rm(lockPath, { recursive: true, force: true }).catch(() => {});
+        continue;
+      }
+      await sleep(25);
+    }
+  }
+
+  throw new Error(`Timed out waiting for YouTube rate-limit lock: ${lockPath}`);
+}
+
+async function withStateLock(options, operation) {
+  const { statePath, lockPath } = getPaths(options);
+  const release = await acquireLock(lockPath, options);
+  try {
+    const state = await readState(statePath);
+    const result = await operation(state, statePath);
+    return result;
+  } finally {
+    await release();
+  }
+}
+
+function getDayRecord(state, dateKey, create = false) {
+  if (!state.days[dateKey] && create) state.days[dateKey] = { entries: {} };
+  const day = state.days[dateKey];
+  if (day && (!day.entries || typeof day.entries !== 'object')) day.entries = {};
+  return day;
+}
+
+function countDay(day) {
+  const entries = Object.values(day?.entries || {});
+  const reservations = entries.filter(entry => entry.status === 'reserved').length;
+  const uploads = entries.filter(entry => entry.status === 'uploaded').length;
+  return {
+    reservations,
+    uploads,
+    count: reservations + uploads
+  };
+}
+
+function normalizeKey(keyOrOptions, maybeOptions) {
+  if (keyOrOptions && typeof keyOrOptions === 'object') {
+    const options = { ...keyOrOptions, ...(maybeOptions || {}) };
+    return { key: options.key || options.reservationKey, options };
+  }
+  return { key: keyOrOptions, options: maybeOptions || {} };
+}
+
+function assertReservationKey(key) {
+  if (typeof key !== 'string' || key.trim().length === 0) {
+    throw new Error('A non-empty reservation key is required');
+  }
+  return key.trim();
+}
+
+async function reservePublicShort(keyOrOptions, maybeOptions) {
+  const normalized = normalizeKey(keyOrOptions, maybeOptions);
+  const key = assertReservationKey(normalized.key);
+  const options = normalized.options;
+  const dateKey = getDateKey(options.now || new Date(), getTimeZone(options));
+  const limit = getDailyLimit(options);
+
+  return withStateLock(options, async (state, statePath) => {
+    const day = getDayRecord(state, dateKey, true);
+    const existing = day.entries[key];
+    const current = countDay(day);
+    if (existing && (existing.status === 'reserved' || existing.status === 'uploaded')) {
+      return {
+        key,
+        dateKey,
+        limit,
+        count: current.count,
+        status: existing.status,
+        alreadyReserved: true
+      };
+    }
+
+    if (current.count >= limit) {
+      const error = new Error(`Daily public Short limit reached (${current.count}/${limit}) for ${dateKey}`);
+      error.code = 'YOUTUBE_PUBLIC_SHORTS_DAILY_LIMIT';
+      error.dateKey = dateKey;
+      error.limit = limit;
+      error.count = current.count;
+      throw error;
+    }
+
+    day.entries[key] = {
+      status: 'reserved',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    };
+    await writeState(statePath, state);
+    return {
+      key,
+      dateKey,
+      limit,
+      count: current.count + 1,
+      status: 'reserved',
+      alreadyReserved: false
+    };
+  });
+}
+
+async function markPublicShortUploaded(keyOrOptions, maybeOptions) {
+  const normalized = normalizeKey(keyOrOptions, maybeOptions);
+  const key = assertReservationKey(normalized.key);
+  const options = normalized.options;
+  const dateKey = getDateKey(options.now || new Date(), getTimeZone(options));
+
+  return withStateLock(options, async (state, statePath) => {
+    const day = getDayRecord(state, dateKey, true);
+    const entry = day.entries[key];
+    if (!entry) throw new Error(`No active rate-limit reservation found for ${key}`);
+    const alreadyUploaded = entry.status === 'uploaded';
+    if (entry.status !== 'uploaded') {
+      entry.status = 'uploaded';
+      entry.updatedAt = new Date().toISOString();
+      await writeState(statePath, state);
+    }
+    const current = countDay(day);
+    return { key, dateKey, status: 'uploaded', count: current.count, alreadyUploaded };
+  });
+}
+
+async function releasePublicShort(keyOrOptions, maybeOptions) {
+  const normalized = normalizeKey(keyOrOptions, maybeOptions);
+  const key = assertReservationKey(normalized.key);
+  const options = normalized.options;
+  const dateKey = getDateKey(options.now || new Date(), getTimeZone(options));
+
+  return withStateLock(options, async (state, statePath) => {
+    const day = getDayRecord(state, dateKey, false);
+    const entry = day?.entries?.[key];
+    if (!entry) return { key, dateKey, released: false, status: null, count: countDay(day).count };
+    if (entry.status === 'uploaded') {
+      return { key, dateKey, released: false, status: 'uploaded', count: countDay(day).count };
+    }
+
+    delete day.entries[key];
+    await writeState(statePath, state);
+    return { key, dateKey, released: true, status: 'released', count: countDay(day).count };
+  });
+}
+
+async function getPublicShortStatus(options = {}) {
+  const dateKey = getDateKey(options.now || new Date(), getTimeZone(options));
+  const limit = getDailyLimit(options);
+  return withStateLock(options, async state => {
+    const day = getDayRecord(state, dateKey, false);
+    const counts = countDay(day);
+    return {
+      dateKey,
+      timeZone: getTimeZone(options),
+      limit,
+      ...counts,
+      entries: Object.entries(day?.entries || {}).map(([key, entry]) => ({ key, ...entry }))
+    };
+  });
+}
+
+async function countPublicShorts(options = {}) {
+  const status = await getPublicShortStatus(options);
+  return status.count;
+}
+
+module.exports = {
+  HARD_LIMIT,
+  count: countPublicShorts,
+  countPublicShorts,
+  getDailyLimit,
+  getDateKey,
+  getPublicShortStatus,
+  getStatus: getPublicShortStatus,
+  getRateLimitPaths: getPaths,
+  isExplicitShort,
+  markPublicShortUploaded,
+  completePublicShort: markPublicShortUploaded,
+  reserve: reservePublicShort,
+  reservePublicShort,
+  release: releasePublicShort,
+  releasePublicShort,
+  releaseReservation: releasePublicShort,
+  status: getPublicShortStatus
+};


### PR DESCRIPTION
## What & why\n\nAdds the Flow still connector, finance sample workflows, local cartoon Short batch renderer, Gemini Omni Short command, Anthropic and TTS setup, safe public-Short rate limiting, and supporting documentation/tests. The branch is based on upstream 260d7a9 so newer product work is preserved.\n\n## How I tested it\n\n- npm test: 49 passed\n- ESLint: passed\n- git diff --check: passed\n\nGenerated media and machine-specific finance outputs remain ignored.